### PR TITLE
fix: create logs directory before initializing file handler

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -17,6 +17,8 @@ def setup_logger(config_path: str = "src/config/logger_setting.yml"):
         raise FileNotFoundError(
             f"Logging configuration file not found at {config_file_path}"
         )
+    # Ensure the logs directory exists
+    os.makedirs("logs", exist_ok=True)
 
     with open(config_file_path, "r") as file:
         config = yaml.safe_load(file)


### PR DESCRIPTION
fix: create logs directory before initializing file handler

- Prevent crash in logging configuration
- Ensure logs/ directory exists before dictConfig