### PR TITLE
fix(reports): support qdrant shift report schema mismatch

### DIFF
--- a/src/ui/reports.py
+++ b/src/ui/reports.py
@@ -56,6 +56,12 @@ def render_reports(*, vector_store) -> None:
 
     payload = fetch_from_qdrant(vector_store, window_id)
     if payload:
-        show_report(f"📄 Report ({window_id})", payload["summary_text"])
+        display_window_id = payload.get("window_id", window_id)
+        summary_text = payload.get("summary_text") or payload.get("summary")
+
+        if summary_text:
+            show_report(f"📄 Report ({display_window_id})", summary_text)
+        else:
+            st.warning("Report found, but summary text is missing.")
     else:
         st.warning("No report found.")

--- a/src/utils/window_helpers.py
+++ b/src/utils/window_helpers.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date
 from typing import Dict, Optional
 
@@ -23,6 +24,32 @@ def build_day_window_id(d: date) -> str:
     return f"day_{d.strftime('%Y-%m-%d')}"
 
 
+def _normalize_report_payload(
+    payload: Dict,
+    *,
+    fallback_window_id: Optional[str] = None,
+) -> Dict:
+    """Return a UI-friendly payload shape for both legacy and current records."""
+    normalized = dict(payload)
+
+    if "summary_text" not in normalized and "summary" in normalized:
+        normalized["summary_text"] = normalized["summary"]
+
+    if "window_id" not in normalized and fallback_window_id:
+        normalized["window_id"] = fallback_window_id
+
+    return normalized
+
+
+def _parse_shift_window_id(window_id: str) -> Optional[tuple[str, str]]:
+    """Extract ``(date_str, shift_label)`` from supported shift window IDs."""
+    match = re.match(r"^(\d{4}-\d{2}-\d{2})_(?:SHIFT|Shift)_([ABC])$", window_id)
+    if not match:
+        return None
+
+    return match.group(1), match.group(2)
+
+
 # Qdrant fetch helper (EXACT ID LOOKUP)
 def fetch_from_qdrant(
     vector_store: QdrantVectorStore,
@@ -40,7 +67,19 @@ def fetch_from_qdrant(
         with_payload=True,
     )
 
-    if not points:
+    if points:
+        return _normalize_report_payload(
+            points[0].payload or {},
+            fallback_window_id=window_id,
+        )
+
+    shift_lookup = _parse_shift_window_id(window_id)
+    if shift_lookup is None:
         return None
 
-    return points[0].payload
+    date_str, shift_label = shift_lookup
+    payload = vector_store.get_report_by_metadata(date_str, shift_label)
+    if payload is None:
+        return None
+
+    return _normalize_report_payload(payload, fallback_window_id=window_id)


### PR DESCRIPTION
1. Fixes Shift Summary report fetching from Qdrant
2. Handles the current payload schema: summary, date, shift
3. Keeps compatibility with the newer UI-expected format
4. Reports now load correctly in the Reports page