### PR TITLE
fix: resolve SQLAlchemy enum mismatch for user roles 

### DIFF
--- a/furnace_data/furnace_data/relational/models.py
+++ b/furnace_data/furnace_data/relational/models.py
@@ -30,7 +30,7 @@ USER_ROLE_ENUM = SqlEnum(
     UserRole,
     name="user_role",
     native_enum=False,
-    validate_strings=True,
+    values_callable=lambda enum: [e.value for e in enum],
 )
 
 


### PR DESCRIPTION
- Fixes LookupError caused by mismatch between DB lowercase values and SQLAlchemy Enum
- Configures Enum to use `.value` via values_callable
- No DB changes required
- Login flow now works correctly