### PR TITLE
Refactored hopper mapping feature to use the new hopper_raw_material_history table instead of hopper_material_history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ The static dataset at `assets/data/ml_dataset_filtered.csv` is the latest commit
 
 ### PostgreSQL
 
-Used for authentication and admin data (users, hoppers, materials, burden config). Accessed via SQLAlchemy through `data/db.py`. Schema uses **SCD Type-2** pattern (`valid_upto IS NULL` = current row).
+Used for authentication and admin data (users, hoppers, materials, burden config). Accessed via SQLAlchemy through `data/db.py`. Burden config uses **SCD Type-2** rows (`valid_upto IS NULL` = current row); hopper raw materials use timestamped all-hopper snapshots in `hopper_raw_material_history`.
 
 ### Tickets Database
 

--- a/furnace_data/furnace_data/relational/models.py
+++ b/furnace_data/furnace_data/relational/models.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from enum import Enum
 
-from sqlalchemy import JSON, Boolean, DateTime
+from sqlalchemy import JSON, BigInteger, Boolean, DateTime
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy import Float, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+HOPPER_MATERIAL_COLUMN_NAMES = tuple(f"hopper_{index:02d}" for index in range(1, 20))
 
 
 def utc_now() -> datetime:
@@ -259,25 +262,42 @@ class FeedbackItem(Base):
 
 
 class HopperMaterialHistory(Base):
-    """SCD Type-2 history for hopper to material assignments."""
+    """Timestamped raw-material snapshot for all hoppers."""
 
-    __tablename__ = "hopper_material_history"
-    __table_args__ = (
-        Index("ix_hopper_history_hopper_valid_from", "hopper", "valid_from"),
-        Index("ix_hopper_history_hopper_valid_upto", "hopper", "valid_upto"),
-    )
+    __tablename__ = "hopper_raw_material_history"
+    __table_args__ = (Index("ix_hopper_raw_material_history_ts", "ts"),)
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    hopper: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
-    material: Mapped[str] = mapped_column(String(256), nullable=False)
-    valid_from: Mapped[datetime] = mapped_column(
-        DateTime(timezone=False), nullable=False
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
     )
-    valid_upto: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=False), nullable=True
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
     )
-    modifier: Mapped[str] = mapped_column(String(128), nullable=False, default="system")
-    ip_address: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    hopper_01: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_02: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_03: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_04: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_05: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_06: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_07: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_08: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_09: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_10: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_11: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_12: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_13: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_14: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_15: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_16: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_17: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_18: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hopper_19: Mapped[str | None] = mapped_column(Text, nullable=True)
+    modifier: Mapped[str] = mapped_column(Text, nullable=False, default="system")
+    ip_address: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
 class BurdenDistributionHistory(Base):

--- a/furnace_data/furnace_data/relational/repositories.py
+++ b/furnace_data/furnace_data/relational/repositories.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime, time, timedelta
 from typing import Any
 from uuid import uuid4
@@ -15,6 +16,7 @@ from .models import (
     Conversation,
     ConversationMessage,
     FeedbackItem,
+    HOPPER_MATERIAL_COLUMN_NAMES,
     HopperMaterialHistory,
     LongTermMemory,
     MemoryDocument,
@@ -134,7 +136,7 @@ class UserRepository:
 
 
 class HopperHistoryRepository:
-    """SCD Type-2 repository for hopper-material mapping."""
+    """Repository for timestamped hopper raw-material snapshots."""
 
     def __init__(self, session_factory: sessionmaker[Session]) -> None:
         """
@@ -148,30 +150,143 @@ class HopperHistoryRepository:
         """
         self._session_factory = session_factory
 
+    @staticmethod
+    def _hopper_to_column(hopper: str) -> str:
+        """
+        Return the raw snapshot column name for a hopper label.
+
+        Args:
+             - hopper: str - Hopper label such as ``HOPPER 01`` or ``hopper_01``.
+
+        Returns:
+             - return: str - Matching snapshot column name.
+        """
+        normalized = hopper.strip().lower().replace(" ", "_")
+        if normalized in HOPPER_MATERIAL_COLUMN_NAMES:
+            return normalized
+
+        match = re.search(r"(\d{1,2})$", normalized)
+        if not match:
+            raise ValueError(f"Unsupported hopper name: {hopper}")
+
+        column = f"hopper_{int(match.group(1)):02d}"
+        if column not in HOPPER_MATERIAL_COLUMN_NAMES:
+            raise ValueError(f"Unsupported hopper name: {hopper}")
+        return column
+
+    @staticmethod
+    def _hopper_name(column: str, hoppers: list[str] | None = None) -> str:
+        """
+        Return the configured display name for a snapshot hopper column.
+
+        Args:
+             - column: str - Snapshot column name, such as ``hopper_01``.
+             - hoppers: list[str] | None - Optional configured hopper labels.
+
+        Returns:
+             - return: str - Display hopper label.
+        """
+        hopper_index = int(column.rsplit("_", 1)[1]) - 1
+        if hoppers and 0 <= hopper_index < len(hoppers):
+            return hoppers[hopper_index]
+        return f"HOPPER {hopper_index + 1:02d}"
+
+    @staticmethod
+    def _configured_columns(hoppers: list[str] | None = None) -> list[str]:
+        """
+        Return snapshot columns represented by the configured hoppers.
+
+        Args:
+             - hoppers: list[str] | None - Optional configured hopper labels.
+
+        Returns:
+             - return: list[str] - Hopper snapshot columns.
+        """
+        if not hoppers:
+            return list(HOPPER_MATERIAL_COLUMN_NAMES)
+        return [HopperHistoryRepository._hopper_to_column(hopper) for hopper in hoppers]
+
+    @staticmethod
+    def _snapshot_values(
+        row: HopperMaterialHistory | None = None,
+    ) -> dict[str, str]:
+        """
+        Return complete hopper column values from a snapshot row.
+
+        Args:
+             - row: HopperMaterialHistory | None - Existing snapshot row.
+
+        Returns:
+             - return: dict[str, str] - Material values keyed by hopper column.
+        """
+        if row is None:
+            return {
+                column: "UNASSIGNED" for column in HOPPER_MATERIAL_COLUMN_NAMES
+            }
+        return {
+            column: getattr(row, column) or "UNASSIGNED"
+            for column in HOPPER_MATERIAL_COLUMN_NAMES
+        }
+
+    @staticmethod
+    def _latest_snapshot(
+        session: Session,
+        *,
+        at_or_before: datetime | None = None,
+    ) -> HopperMaterialHistory | None:
+        """
+        Return the newest snapshot, optionally constrained by timestamp.
+
+        Args:
+             - session: Session - Active SQLAlchemy session.
+             - at_or_before: datetime | None - Optional maximum snapshot timestamp.
+
+        Returns:
+             - return: HopperMaterialHistory | None - Latest matching snapshot row.
+        """
+        stmt = select(HopperMaterialHistory)
+        if at_or_before is not None:
+            stmt = stmt.where(HopperMaterialHistory.ts <= at_or_before)
+        stmt = stmt.order_by(
+            HopperMaterialHistory.ts.desc(),
+            HopperMaterialHistory.id.desc(),
+        ).limit(1)
+        return session.execute(stmt).scalar_one_or_none()
+
     def seed_hoppers_if_missing(self, hoppers: list[str], now: datetime) -> None:
         """
-        Seed missing hoppers with UNASSIGNED records.
+        Seed the initial all-hopper snapshot when history is empty.
 
         Args:
              - hoppers: list[str] - Hopper names that should exist.
-             - now: datetime - Timestamp to use as the valid-from time.
+             - now: datetime - Timestamp to use for the seed snapshot.
 
         Returns:
              - return: None - This function does not return a value.
         """
         with self._session_factory() as session:
-            existing_stmt = select(HopperMaterialHistory.hopper).distinct()
-            existing = {row[0] for row in session.execute(existing_stmt).all()}
-            for hopper in hoppers:
-                if hopper in existing:
-                    continue
+            latest = self._latest_snapshot(session)
+            if latest is None:
                 session.add(
                     HopperMaterialHistory(
-                        hopper=hopper,
-                        material="UNASSIGNED",
-                        valid_from=now,
+                        ts=now,
+                        **self._snapshot_values(),
                     )
                 )
+                session.commit()
+                return
+
+            configured_columns = self._configured_columns(hoppers)
+            has_missing_configured_value = any(
+                not getattr(latest, column) for column in configured_columns
+            )
+            if not has_missing_configured_value:
+                return
+
+            values = self._snapshot_values(latest)
+            for column in configured_columns:
+                values[column] = values[column] or "UNASSIGNED"
+            session.add(HopperMaterialHistory(ts=now, **values))
             session.commit()
 
     def update_hopper_material_with_time(
@@ -184,59 +299,84 @@ class HopperHistoryRepository:
         ip_address: str,
     ) -> None:
         """
-        Close the current hopper-material row and insert a new active record.
+        Insert a new all-hopper snapshot with one hopper changed.
 
         Args:
              - hopper: str - Hopper name to update.
              - material: str - New material assigned to the hopper.
-             - from_time: datetime - Time from which the new assignment is valid.
+             - from_time: datetime - Snapshot timestamp for the new assignment.
              - modifier: str - User or process making the change.
              - ip_address: str - Client IP address for audit context.
 
         Returns:
              - return: None - This function does not return a value.
         """
+        self.update_hopper_materials_with_time(
+            updates={hopper: material},
+            from_time=from_time,
+            modifier=modifier,
+            ip_address=ip_address,
+        )
+
+    def update_hopper_materials_with_time(
+        self,
+        *,
+        updates: dict[str, str],
+        from_time: datetime,
+        modifier: str,
+        ip_address: str,
+    ) -> None:
+        """
+        Insert one all-hopper snapshot after applying material changes.
+
+        Args:
+             - updates: dict[str, str] - Hopper-to-material changes to apply.
+             - from_time: datetime - Snapshot timestamp for the new assignments.
+             - modifier: str - User or process making the change.
+             - ip_address: str - Client IP address for audit context.
+
+        Returns:
+             - return: None - This function does not return a value.
+        """
+        if not updates:
+            return
+
         with self._session_factory() as session:
-            close_stmt = (
-                update(HopperMaterialHistory)
-                .where(
-                    and_(
-                        HopperMaterialHistory.hopper == hopper,
-                        HopperMaterialHistory.valid_upto.is_(None),
-                    )
-                )
-                .values(valid_upto=from_time - timedelta(seconds=1))
-            )
-            session.execute(close_stmt)
+            latest = self._latest_snapshot(session, at_or_before=from_time)
+            values = self._snapshot_values(latest)
+            for hopper, material in updates.items():
+                values[self._hopper_to_column(hopper)] = material
 
             session.add(
                 HopperMaterialHistory(
-                    hopper=hopper,
-                    material=material,
-                    valid_from=from_time,
+                    ts=from_time,
                     modifier=modifier,
                     ip_address=ip_address,
+                    **values,
                 )
             )
             session.commit()
 
-    def get_current_hopper_materials(self) -> dict[str, str]:
+    def get_current_hopper_materials(
+        self,
+        hoppers: list[str] | None = None,
+    ) -> dict[str, str]:
         """
         Return the current hopper-to-material map.
 
         Args:
-             - None
+             - hoppers: list[str] | None - Optional configured hopper labels.
 
         Returns:
              - return: dict[str, str] - Mapping from hopper name to current material.
         """
         with self._session_factory() as session:
-            stmt = (
-                select(HopperMaterialHistory.hopper, HopperMaterialHistory.material)
-                .where(HopperMaterialHistory.valid_upto.is_(None))
-                .order_by(HopperMaterialHistory.hopper.asc())
-            )
-            return {row[0]: row[1] for row in session.execute(stmt).all()}
+            latest = self._latest_snapshot(session)
+            values = self._snapshot_values(latest)
+            return {
+                self._hopper_name(column, hoppers): values[column]
+                for column in self._configured_columns(hoppers)
+            }
 
     def get_hopper_material_at(self, hopper: str, ts: datetime) -> str | None:
         """
@@ -250,23 +390,10 @@ class HopperHistoryRepository:
              - return: str | None - Assigned material when found, otherwise None.
         """
         with self._session_factory() as session:
-            stmt = (
-                select(HopperMaterialHistory.material)
-                .where(
-                    and_(
-                        HopperMaterialHistory.hopper == hopper,
-                        HopperMaterialHistory.valid_from <= ts,
-                        or_(
-                            HopperMaterialHistory.valid_upto.is_(None),
-                            HopperMaterialHistory.valid_upto >= ts,
-                        ),
-                    )
-                )
-                .order_by(HopperMaterialHistory.valid_from.desc())
-                .limit(1)
-            )
-            row = session.execute(stmt).first()
-            return row[0] if row else None
+            latest = self._latest_snapshot(session, at_or_before=ts)
+            if latest is None:
+                return None
+            return getattr(latest, self._hopper_to_column(hopper)) or "UNASSIGNED"
 
     def get_hopper_material_history(self) -> list[dict[str, Any]]:
         """
@@ -280,18 +407,18 @@ class HopperHistoryRepository:
         """
         with self._session_factory() as session:
             stmt = select(HopperMaterialHistory).order_by(
-                HopperMaterialHistory.hopper.asc(),
-                HopperMaterialHistory.valid_from.desc(),
+                HopperMaterialHistory.ts.desc(),
                 HopperMaterialHistory.id.desc(),
             )
             rows = session.execute(stmt).scalars().all()
             return [
                 {
                     "id": row.id,
-                    "hopper": row.hopper,
-                    "material": row.material,
-                    "valid_from": row.valid_from,
-                    "valid_upto": row.valid_upto,
+                    "ts": row.ts,
+                    **{
+                        column: getattr(row, column)
+                        for column in HOPPER_MATERIAL_COLUMN_NAMES
+                    },
                     "modifier": row.modifier,
                     "ip_address": row.ip_address,
                 }

--- a/src/data/db.py
+++ b/src/data/db.py
@@ -17,14 +17,41 @@ import yaml
 from dotenv import load_dotenv
 from sqlalchemy.exc import IntegrityError
 
-try:
-    from furnace_data import relational as _relational
-except ModuleNotFoundError:
-    # Prefer in-repo furnace_data source when an older site-packages build is present.
-    furnace_data_src = Path(__file__).resolve().parents[2] / "furnace_data"
-    if str(furnace_data_src) not in sys.path:
-        sys.path.insert(0, str(furnace_data_src))
-    from furnace_data import relational as _relational
+furnace_data_src = Path(__file__).resolve().parents[2] / "furnace_data"
+if furnace_data_src.exists() and str(furnace_data_src) not in sys.path:
+    sys.path.insert(0, str(furnace_data_src))
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _drop_stale_furnace_data_modules() -> None:
+    local_package_dir = furnace_data_src / "furnace_data"
+    loaded_package = sys.modules.get("furnace_data")
+    if loaded_package is None:
+        return
+
+    loaded_file = getattr(loaded_package, "__file__", None)
+    is_local_package = bool(
+        loaded_file
+        and _is_relative_to(Path(loaded_file).resolve(), local_package_dir)
+    )
+    if is_local_package:
+        return
+
+    for module_name in list(sys.modules):
+        if module_name == "furnace_data" or module_name.startswith("furnace_data."):
+            del sys.modules[module_name]
+
+
+_drop_stale_furnace_data_modules()
+
+from furnace_data import relational as _relational
 
 Base = _relational.Base
 BurdenHistoryRepository = _relational.BurdenHistoryRepository
@@ -75,7 +102,7 @@ class Database:
         )
         self._hopper_repository.seed_hoppers_if_missing(
             hoppers=self.hoppers,
-            now=datetime.now(timezone.utc).replace(tzinfo=None),
+            now=datetime.now(timezone.utc),
         )
 
     def add_user(self, username: str, password: str, role: str = "user") -> None:
@@ -155,7 +182,7 @@ class Database:
         modifier: str,
         ip_address: str,
     ) -> None:
-        """Record a new hopper-to-material assignment using SCD Type-2."""
+        """Record a new raw-material snapshot with one hopper changed."""
         if hopper not in self.hoppers:
             raise ValueError("Invalid hopper")
         if material not in self.materials and material != "UNASSIGNED":
@@ -169,16 +196,54 @@ class Database:
             ip_address=ip_address,
         )
 
+    def update_hopper_materials_with_time(
+        self,
+        updates: dict[str, str],
+        from_time: datetime,
+        modifier: str,
+        ip_address: str,
+    ) -> None:
+        """Record one raw-material snapshot with multiple hopper changes."""
+        invalid_hoppers = [hopper for hopper in updates if hopper not in self.hoppers]
+        if invalid_hoppers:
+            raise ValueError(f"Invalid hopper: {invalid_hoppers[0]}")
+
+        invalid_materials = [
+            material
+            for material in updates.values()
+            if material not in self.materials and material != "UNASSIGNED"
+        ]
+        if invalid_materials:
+            raise ValueError(f"Invalid material: {invalid_materials[0]}")
+
+        self._hopper_repository.update_hopper_materials_with_time(
+            updates=updates,
+            from_time=from_time,
+            modifier=modifier,
+            ip_address=ip_address,
+        )
+
     def get_current_hopper_materials(self) -> dict[str, str]:
         """Return current hopper-to-material mapping."""
-        return self._hopper_repository.get_current_hopper_materials()
+        try:
+            return self._hopper_repository.get_current_hopper_materials(
+                hoppers=self.hoppers
+            )
+        except TypeError as exc:
+            if "unexpected keyword argument 'hoppers'" not in str(exc):
+                raise
+            current_map = self._hopper_repository.get_current_hopper_materials()
+            return {
+                hopper: current_map.get(hopper, "UNASSIGNED")
+                for hopper in self.hoppers
+            }
 
     def get_hopper_material_at(self, hopper: str, ts: datetime) -> str | None:
         """Return material assigned to hopper at timestamp."""
         return self._hopper_repository.get_hopper_material_at(hopper=hopper, ts=ts)
 
     def get_hopper_material_history(self) -> list[dict[str, Any]]:
-        """Return full hopper-material history rows."""
+        """Return full hopper raw-material snapshot rows."""
         return self._hopper_repository.get_hopper_material_history()
 
     def delete_hopper_material_history(self, record_ids: list[int]) -> None:

--- a/src/ui/hopper_admin_page.py
+++ b/src/ui/hopper_admin_page.py
@@ -2,8 +2,8 @@
 
 Allows supervisors and admins to assign raw materials to hoppers with
 a user-specified effective timestamp.  All changes are written via
-:meth:`~data.db.Database.update_hopper_material_with_time` which appends
-a new SCD Type-2 history row.
+:meth:`~data.db.Database.update_hopper_materials_with_time` which appends
+a new all-hopper raw-material snapshot.
 """
 
 from datetime import datetime
@@ -16,8 +16,8 @@ from data.db import Database
 class HopperAdminPage:
     """Streamlit admin interface for hopper-to-material mapping management.
 
-    Derives the current mapping entirely from the ``hopper_material_history``
-    table (no separate snapshot table required).
+    Derives the current mapping from the latest row in
+    ``hopper_raw_material_history``.
 
     Attributes:
         db:              :class:`~data.db.Database` instance.
@@ -32,7 +32,6 @@ class HopperAdminPage:
         self.materials = self.db.materials
         self.hoppers = self.db.hoppers
 
-        # \u2705 UPDATED: derive current mapping from history table
         self.hopper_materials = self.db.get_current_hopper_materials()
 
     def get_client_ip(self):
@@ -110,34 +109,31 @@ class HopperAdminPage:
         ip_address: str,
     ) -> None:
 
-        changes = 0
-        errors = False
+        changes = {
+            hopper: new_material
+            for hopper, new_material in updated_values.items()
+            if new_material != self.hopper_materials.get(hopper, "UNASSIGNED")
+        }
 
-        for hopper, new_material in updated_values.items():
-            current_material = self.hopper_materials.get(hopper, "UNASSIGNED")
+        if not changes:
+            st.info("ℹ️ No changes detected.")
+            return
 
-            if new_material != current_material:
-                try:
-                    self.db.update_hopper_material_with_time(
-                        hopper=hopper,
-                        material=new_material,
-                        from_time=from_time,
-                        modifier=username,
-                        ip_address=ip_address,
-                    )
-                    changes += 1
-                except Exception as e:
-                    st.error(f"❌ Error updating {hopper}: {e}")
-                    errors = True
+        try:
+            self.db.update_hopper_materials_with_time(
+                updates=changes,
+                from_time=from_time,
+                modifier=username,
+                ip_address=ip_address,
+            )
+        except Exception as e:
+            st.error(f"❌ Error updating hopper materials: {e}")
+            return
 
-        if not errors:
-            if changes == 0:
-                st.info("ℹ️ No changes detected.")
-            else:
-                st.session_state["hopper_success_message"] = (
-                    f"✅ {changes} hopper(s) updated successfully."
-                )
-                st.rerun()
+        st.session_state["hopper_success_message"] = (
+            f"✅ {len(changes)} hopper(s) updated successfully."
+        )
+        st.rerun()
 
     # ----------------------------------------------------
     # Render Page
@@ -169,10 +165,8 @@ class HopperAdminPage:
                 },
                 column_order=[
                     "id",
-                    "hopper",
-                    "material",
-                    "valid_from",
-                    "valid_upto",
+                    "ts",
+                    *[f"hopper_{index:02d}" for index in range(1, 20)],
                     "modifier",
                     "ip_address",
                 ],

--- a/tests/test_database_facade_sqlalchemy.py
+++ b/tests/test_database_facade_sqlalchemy.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
 from src.data.db import Database
 
 
-def _sqlite_url() -> tuple[str, Path]:
-    db_name = f"db_facade_test_{uuid4().hex}.db"
-    db_path = Path.cwd() / db_name
-    return f"sqlite:///{db_path.as_posix()}", db_path
+def _sqlite_url() -> tuple[str, Path | None]:
+    return "sqlite:///:memory:", None
 
 
 def test_auth_seed_and_user_registration_flow() -> None:
@@ -33,27 +30,30 @@ def test_auth_seed_and_user_registration_flow() -> None:
             db.add_user("qa_user", "pass123", "user")
     finally:
         db.dispose()
-        if db_path.exists():
+        if db_path is not None and db_path.exists():
             db_path.unlink()
 
 
-def test_hopper_history_scd_type2_update() -> None:
-    """Hopper material update should close old row and insert new active row."""
+def test_hopper_history_snapshot_update() -> None:
+    """Hopper material update should insert one full snapshot row."""
     db_url, db_path = _sqlite_url()
     db = Database(db_url=db_url)
     try:
         assert db.hoppers, "Expected hopper list from materials.yml."
         hopper = db.hoppers[0]
+        second_hopper = db.hoppers[1]
 
         current_map = db.get_current_hopper_materials()
         original_material = current_map[hopper]
+        second_original_material = current_map[second_hopper]
 
         next_material = (
             db.materials[0]
             if db.materials and db.materials[0] != original_material
             else "UNASSIGNED"
         )
-        from_time = datetime.utcnow()
+        from_time = datetime.now(timezone.utc)
+        original_history_count = len(db.get_hopper_material_history())
 
         db.update_hopper_material_with_time(
             hopper=hopper,
@@ -65,20 +65,35 @@ def test_hopper_history_scd_type2_update() -> None:
 
         updated_map = db.get_current_hopper_materials()
         assert updated_map[hopper] == next_material
+        assert updated_map[second_hopper] == second_original_material
 
         at_new_time = db.get_hopper_material_at(hopper, from_time + timedelta(seconds=1))
         assert at_new_time == next_material
 
-        history = [
-            row for row in db.get_hopper_material_history() if row["hopper"] == hopper
-        ]
-        assert len(history) >= 2
-        assert history[0]["material"] == next_material
-        assert history[1]["material"] == original_material
-        assert history[1]["valid_upto"] is not None
+        history = db.get_hopper_material_history()
+        assert len(history) == original_history_count + 1
+        assert history[0]["hopper_01"] == next_material
+        assert history[0]["hopper_02"] == second_original_material
+
+        second_next_material = db.materials[1] if len(db.materials) > 1 else "UNASSIGNED"
+        batch_time = from_time + timedelta(minutes=1)
+        db.update_hopper_materials_with_time(
+            updates={
+                hopper: original_material,
+                second_hopper: second_next_material,
+            },
+            from_time=batch_time,
+            modifier="qa",
+            ip_address="127.0.0.1",
+        )
+
+        batch_history = db.get_hopper_material_history()
+        assert len(batch_history) == len(history) + 1
+        assert batch_history[0]["hopper_01"] == original_material
+        assert batch_history[0]["hopper_02"] == second_next_material
     finally:
         db.dispose()
-        if db_path.exists():
+        if db_path is not None and db_path.exists():
             db_path.unlink()
 
 
@@ -87,7 +102,7 @@ def test_burden_history_update_current_values_and_delete() -> None:
     db_url, db_path = _sqlite_url()
     db = Database(db_url=db_url)
     try:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         db.update_burden_field(
             field_name="COKE_CHARGE_PATTERN",
@@ -114,5 +129,5 @@ def test_burden_history_update_current_values_and_delete() -> None:
         assert db.get_burden_history() == []
     finally:
         db.dispose()
-        if db_path.exists():
+        if db_path is not None and db_path.exists():
             db_path.unlink()


### PR DESCRIPTION
Changes
- Updated models and repository logic for the new schema.
- Added support for snapshot-based hopper data (hopper_01 to hopper_19).
- Updated hopper admin page functionality.
- Added Alembic migration for the new table structure.
- Updated related database handling and test cases.