### PR TITLE
Update oxygen flow logic in shift report to use MCART API value

### DIFF
--- a/src/config/setting_ds_dv.yml
+++ b/src/config/setting_ds_dv.yml
@@ -489,6 +489,7 @@ data_mapping: # Using InfluxDB Measurement or Table names as keys
 
     BF2_TUYERE VELOCITY: tuyere_velocity
     BF2_PRODUCTION TONNES PER HR: production_per_hour
+    BF2_OXYGEN FLOW: oxygen_flow
     BF2_OXYGEN ENRICHMENT PCT: oxygen_enrichment_pct
     BF2_THEORETICAL PRODUCTION PER DAY: theoretical_production_per_day
     BF2_STEAM INJECTION: steam_injections

--- a/src/reports/shift_report/builder.py
+++ b/src/reports/shift_report/builder.py
@@ -27,6 +27,7 @@ _ONLINE: dict[str, str] = {
     "perm":          "Process Params - BF2_BODY_PERMEABILITY",
     "etaco":         "Process Params - BF2_BODY_ETACO",
     "raft":          "Process Params - BF2_BODY_RAFT",
+    "o2_flow":       "Process Params - BF2_OXYGEN FLOW",
     "o2_enr":        "Process Params - BF2_OXYGEN ENRICHMENT PCT",
     "fuel_rate":     "Process Params - BF2_FUEL RATE PER THM",
     "coke_rate":     "Process Params - BF2_COKE RATE PER THM",
@@ -191,11 +192,6 @@ class ShiftBuilder(ReportBuilder[ShiftRawData, ShiftReportData]):
         else:
             total_charges = None
 
-        # O2 flow (derived)
-        hb_vol = _mean(df, "hb_vol")
-        o2_enr = _mean(df, "o2_enr")
-        o2_flow_mean = round(hb_vol * o2_enr / 100, 2) if hb_vol and o2_enr else None
-
         # Slag basicity
         cao = _hm_mean(hm, "slag_cao")
         sio2 = _hm_mean(hm, "slag_sio2")
@@ -240,7 +236,7 @@ class ShiftBuilder(ReportBuilder[ShiftRawData, ShiftReportData]):
             blast_volume=_ps(df, "hb_vol"),
             blast_temp=_ps(df, "hb_temp"),
             blast_pressure=_ps(df, "hb_press"),
-            o2_flow=ParamStats(mean=o2_flow_mean, std=None),
+            o2_flow=_ps(df, "o2_flow"),
             o2_enrichment=_ps(df, "o2_enr"),
             permeability=_ps(df, "perm"),
             etaco=_ps(df, "etaco"),


### PR DESCRIPTION
Description

Previously, oxygen flow in the shift report was derived using calculation logic.
Since the direct oxygen flow value is now available from the MCART API, the report has been updated to consume theMCART API value directly.

Changes Made

- Removed calculated oxygen flow usage
- Integrated direct oxygen flow value from API
