### PR TITLE
refactor(shift-reports): introduce structured report document architecture

### DIFF
--- a/src/reports/rendering.py
+++ b/src/reports/rendering.py
@@ -1,0 +1,159 @@
+"""Structured report rendering primitives shared by UI and report builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Literal, Sequence
+
+Placement = Literal["left", "right"]
+
+_BLOCK_RE = re.compile(r"\n{2,}")
+_BOLD_RE = re.compile(r"\*\*(.*?)\*\*")
+_BR_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_TABLE_SEP_RE = re.compile(r"^\|[-:| ]+\|", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class ReportSection:
+    """One tabular section in a report."""
+
+    title: str
+    headers: tuple[str, ...]
+    rows: tuple[tuple[str, ...], ...]
+    placement: Placement = "right"
+
+    @classmethod
+    def from_rows(
+        cls,
+        title: str,
+        headers: Sequence[str],
+        rows: Sequence[Sequence[object]],
+        *,
+        placement: Placement = "right",
+    ) -> "ReportSection":
+        width = len(headers)
+        return cls(
+            title=title,
+            headers=tuple(str(header) for header in headers),
+            rows=tuple(_coerce_row(row, width) for row in rows),
+            placement=placement,
+        )
+
+
+@dataclass(frozen=True)
+class ReportNote:
+    """Non-tabular report text, such as raw material usage notes."""
+
+    text: str
+    placement: Placement = "right"
+    kind: str = "note"
+
+
+@dataclass(frozen=True)
+class ReportDocument:
+    """Renderable report composed of preamble text, tables, and notes."""
+
+    title: str
+    pre_blocks: tuple[str, ...] = field(default_factory=tuple)
+    sections: tuple[ReportSection, ...] = field(default_factory=tuple)
+    notes: tuple[ReportNote, ...] = field(default_factory=tuple)
+
+
+def clean_inline(value: str) -> str:
+    return _BOLD_RE.sub(r"\1", _BR_RE.sub(" ", str(value)).replace("&nbsp;", " ")).strip()
+
+
+def markdown_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    width = len(headers)
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join(["---"] * width) + "|",
+    ]
+    for row in rows:
+        cells = list(_coerce_row(row, width))
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines)
+
+
+def _coerce_row(row: Sequence[object], width: int) -> tuple[str, ...]:
+    cells = [str(cell) for cell in row[:width]]
+    return tuple([*cells, *[""] * max(0, width - len(cells))])
+
+
+def document_to_markdown(document: ReportDocument) -> str:
+    parts: list[str] = [block for block in document.pre_blocks if block.strip()]
+    parts.extend(markdown_table(section.headers, section.rows) for section in document.sections)
+    parts.extend(note.text for note in document.notes if note.text.strip())
+    return "\n\n".join(parts)
+
+
+def split_markdown_blocks(summary_text: str) -> tuple[list[str], list[str], list[str]]:
+    tables, pre, post, seen_table = [], [], [], False
+    for block in filter(None, (b.strip() for b in _BLOCK_RE.split(summary_text.strip()))):
+        if _TABLE_SEP_RE.search(block):
+            tables.append(block)
+            seen_table = True
+        elif seen_table:
+            post.append(block)
+        else:
+            pre.append(block)
+    return tables, pre, post
+
+
+def parse_markdown_table(markdown: str) -> tuple[list[str], list[list[str]]]:
+    lines = [line for line in markdown.splitlines() if line.strip().startswith("|")]
+    sep_idx = next((idx for idx, line in enumerate(lines) if is_table_separator(line)), -1)
+    if sep_idx <= 0:
+        return [], []
+
+    headers = table_cells(lines[sep_idx - 1])
+    width = len(headers)
+    rows = [
+        (table_cells(line) + [""] * width)[:width]
+        for line in lines[sep_idx + 1 :]
+        if not is_table_separator(line)
+    ]
+    return headers, rows
+
+
+def table_cells(row: str) -> list[str]:
+    return [clean_inline(cell) for cell in row.strip().strip("|").split("|")]
+
+
+def is_table_separator(row: str) -> bool:
+    cells = table_cells(row)
+    return bool(cells) and all(re.fullmatch(r":?-{3,}:?", cell) for cell in cells)
+
+
+def is_section_row(row: Sequence[str]) -> bool:
+    return bool(row) and bool(row[0]) and all(not cell for cell in row[1:])
+
+
+def document_from_markdown(
+    title: str,
+    summary_text: str,
+    *,
+    table_titles: Sequence[str] = (),
+    default_left_count: int = 1,
+) -> ReportDocument:
+    tables, pre, post = split_markdown_blocks(summary_text)
+    sections: list[ReportSection] = []
+    for index, markdown in enumerate(tables):
+        headers, rows = parse_markdown_table(markdown)
+        if not headers:
+            continue
+        section_title = (
+            table_titles[index] if index < len(table_titles) else f"Report Table {index + 1}"
+        )
+        placement: Placement = "left" if index < default_left_count else "right"
+        sections.append(
+            ReportSection.from_rows(section_title, headers, rows, placement=placement)
+        )
+
+    return ReportDocument(
+        title=title,
+        pre_blocks=tuple(pre),
+        sections=tuple(sections),
+        notes=tuple(ReportNote(block, placement="right") for block in post),
+    )

--- a/src/reports/shift_report/builder.py
+++ b/src/reports/shift_report/builder.py
@@ -1,4 +1,4 @@
-"""Compute all shift metrics from raw DataFrames — pure Python, no I/O."""
+"""Compute all shift metrics from raw DataFrames; pure Python, no I/O."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ from typing import Any, Literal, Optional
 import pandas as pd
 
 from config.config_loader import load_config
-from data.material_mapping import MaterialNameMapper
 from reports.base import ReportBuilder
 from reports.shift_report.data import (
     ParamStats,
@@ -16,8 +15,12 @@ from reports.shift_report.data import (
     ShiftReportData,
     TempRow,
 )
+from reports.shift_report.materials import (
+    MaterialAliasResolver,
+    material_code_candidates,
+)
 
-# ── Column name registry ────────────────────────────────────────────────────
+# Column name registry.
 # Keys are short internal names; values are the exact DataFrame column names
 # produced by fetch_online_df() and fetch_offline_data().
 
@@ -118,16 +121,11 @@ _FINES_SOURCE_BY_CHARGE_COL = {
     for source, spec in _FINES_SOURCES.items()
     for col in _charge_columns(spec)
 }
-try:
-    _MATERIAL_NAME_MAPPER = MaterialNameMapper.from_file()
-except Exception:
-    _MATERIAL_NAME_MAPPER = None
-
-# ── Status thresholds ────────────────────────────────────────────────────────
+# Status thresholds.
 _THRESH = dict(_SHIFT_REPORT_CONFIG.get("status_thresholds") or {})
 
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
+# Helpers.
 
 
 def _mean(df: pd.DataFrame, key: str) -> Optional[float]:
@@ -192,48 +190,10 @@ def _charge_sum(df: pd.DataFrame, key: str) -> Optional[float]:
     return None
 
 
-def _material_name_lookup(materials_df: pd.DataFrame) -> dict[str, str]:
-    if materials_df.empty or not {"material_code", "material_name"}.issubset(
-        materials_df.columns
-    ):
-        return {}
-
-    df = materials_df.copy()
-    if "is_active" in df.columns:
-        df = df[df["is_active"].fillna(True).astype(bool)]
-
-    lookup: dict[str, str] = {}
-    for _, row in df.dropna(subset=["material_code", "material_name"]).iterrows():
-        code = str(row["material_code"])
-        name = str(row["material_name"])
-        code_without_underscores = code.replace("_", "")
-        for key in dict.fromkeys(
-            [
-                code,
-                code.casefold(),
-                code_without_underscores,
-                code_without_underscores.casefold(),
-            ]
-        ):
-            lookup.setdefault(key, name)
-    return lookup
-
-
-def _display_material_name(material_name: str) -> str:
-    if _MATERIAL_NAME_MAPPER is None:
-        return material_name
-    return _MATERIAL_NAME_MAPPER.primary_client_name_for_material(material_name)
-
-
-def _display_material_code(material_code: str) -> str:
-    return material_code.replace("_", "")
-
-
 def _used_charge_materials(
     charge_df: pd.DataFrame,
-    materials_df: pd.DataFrame,
+    resolver: MaterialAliasResolver,
 ) -> dict[str, str]:
-    material_names = _material_name_lookup(materials_df)
     used: dict[str, str] = {}
 
     for label, key in (("Flux", "flux"), ("Ore", "ore")):
@@ -242,19 +202,7 @@ def _used_charge_materials(
         for charge_col in _CHARGE_COLS.get(key, []):
             if _charge_column_total(charge_df, charge_col) <= 0:
                 continue
-            material_codes = _material_candidates(charge_col)
-            material_name = next(
-                (
-                    material_names[material_code]
-                    for material_code in material_codes
-                    if material_code in material_names
-                ),
-                None,
-            )
-            if material_name:
-                item = _display_material_name(material_name)
-            else:
-                item = _display_material_code(material_codes[0])
+            item = resolver.display_name(_material_candidates(charge_col))
             if item not in seen:
                 items.append(item)
                 seen.add(item)
@@ -280,11 +228,7 @@ def _analysis_with_time(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _material_candidates(charge_col: str) -> list[str]:
-    base = charge_col.removesuffix("_mt")
-    return _MATERIAL_CODE_CANDIDATES.get(
-        charge_col,
-        list(dict.fromkeys([base, base.replace("_", "")])),
-    )
+    return material_code_candidates(charge_col, _MATERIAL_CODE_CANDIDATES)
 
 
 def _analysis_rows(
@@ -458,15 +402,15 @@ def _status(
     return "UNSTABLE", flags
 
 
-# ── Builder ──────────────────────────────────────────────────────────────────
+# Builder.
 
 
 class ShiftBuilder(ReportBuilder[ShiftRawData, ShiftReportData]):
     def build(self, raw: ShiftRawData) -> ShiftReportData:  # type: ignore[override]
         df = raw.online_df
-        #
         hm = raw.hm_slag_df
         ch = raw.charge_df
+        material_resolver = MaterialAliasResolver.from_dataframe(raw.materials_df)
 
         # One row in offline_feed.charge_data represents one charge in the shift.
         total_charges = int(ch.shape[0]) if not ch.empty else 0
@@ -548,5 +492,5 @@ class ShiftBuilder(ReportBuilder[ShiftRawData, ShiftReportData]):
             hearth_6_1_b=_mean(df, "hearth_6_1_b"),
             burden_moisture_input=burden_moisture_input,
             fines_input=fines_input,
-            used_materials=_used_charge_materials(ch, raw.materials_df),
+            used_materials=_used_charge_materials(ch, material_resolver),
         )

--- a/src/reports/shift_report/fetcher.py
+++ b/src/reports/shift_report/fetcher.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+from functools import lru_cache
+import logging
 from typing import Literal
 
 import pandas as pd
@@ -28,6 +30,7 @@ _MATERIAL_FINES_TABLE = {
     str(key): str(value)
     for key, value in _SHIFT_REPORT_CONFIG.get("material_fines_table", {}).items()
 }
+logger = logging.getLogger(__name__)
 
 
 def _safe(df: pd.DataFrame | None) -> pd.DataFrame:
@@ -40,6 +43,7 @@ def _safe_table(
     try:
         return _safe(_fetch_neon_table(table_name, time_range=(start_utc, end_utc)))
     except Exception:
+        logger.warning("Failed to fetch shift report table %s", table_name, exc_info=True)
         return pd.DataFrame()
 
 
@@ -59,6 +63,7 @@ def _safe_material_fines_table(start_utc: datetime, end_utc: datetime) -> pd.Dat
             params={"start_time": start_utc, "end_time": end_utc},
         )
     except Exception:
+        logger.warning("Failed to fetch material fines table", exc_info=True)
         return pd.DataFrame()
     finally:
         if engine is not None:
@@ -71,16 +76,23 @@ def _safe_material_fines_table(start_utc: datetime, end_utc: datetime) -> pd.Dat
     return df
 
 
+@lru_cache(maxsize=1)
+def _cached_materials_table() -> pd.DataFrame:
+    return _safe(
+        _fetch_neon_table(
+            "materials",
+            time_range="full",
+            columns=("material_code", "material_name", "is_active"),
+        )
+    )
+
+
 def _safe_materials_table() -> pd.DataFrame:
     try:
-        return _safe(
-            _fetch_neon_table(
-                "materials",
-                time_range="full",
-                columns=("material_code", "material_name", "is_active"),
-            )
-        )
+        return _cached_materials_table().copy()
     except Exception:
+        logger.warning("Failed to fetch materials table", exc_info=True)
+        _cached_materials_table.cache_clear()
         return pd.DataFrame()
 
 

--- a/src/reports/shift_report/materials.py
+++ b/src/reports/shift_report/materials.py
@@ -1,0 +1,87 @@
+"""Material-code alias resolution for shift reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import logging
+from typing import Mapping, Sequence
+
+import pandas as pd
+
+from data.material_mapping import MaterialNameMapper
+
+logger = logging.getLogger(__name__)
+
+
+def material_code_candidates(
+    charge_col: str,
+    configured: Mapping[str, Sequence[str]],
+) -> list[str]:
+    base = charge_col.removesuffix("_mt")
+    return list(dict.fromkeys(configured.get(charge_col, (base, base.replace("_", "")))))
+
+
+def display_material_code(material_code: str) -> str:
+    return material_code.replace("_", "")
+
+
+@dataclass(frozen=True)
+class MaterialAliasResolver:
+    """Resolve charge-column material aliases to client-facing material names."""
+
+    material_names: Mapping[str, str]
+    mapper: MaterialNameMapper | None = None
+
+    @classmethod
+    def from_dataframe(cls, materials_df: pd.DataFrame) -> "MaterialAliasResolver":
+        return cls(_material_name_lookup(materials_df), _load_mapper())
+
+    def display_name(self, material_codes: Sequence[str]) -> str:
+        for code in material_codes:
+            material_name = self.material_names.get(code) or self.material_names.get(
+                code.casefold()
+            )
+            if material_name:
+                return self._display_material_name(material_name)
+        return display_material_code(material_codes[0]) if material_codes else "-"
+
+    def _display_material_name(self, material_name: str) -> str:
+        if self.mapper is None:
+            return material_name
+        return self.mapper.primary_client_name_for_material(material_name)
+
+
+@lru_cache(maxsize=1)
+def _load_mapper() -> MaterialNameMapper | None:
+    try:
+        return MaterialNameMapper.from_file()
+    except Exception:
+        logger.warning("Unable to load materials_map.yml", exc_info=True)
+        return None
+
+
+def _material_name_lookup(materials_df: pd.DataFrame) -> dict[str, str]:
+    if materials_df.empty or not {"material_code", "material_name"}.issubset(
+        materials_df.columns
+    ):
+        return {}
+
+    df = materials_df.copy()
+    if "is_active" in df.columns:
+        df = df[df["is_active"].fillna(True).astype(bool)]
+
+    lookup: dict[str, str] = {}
+    for _, row in df.dropna(subset=["material_code", "material_name"]).iterrows():
+        code = str(row["material_code"])
+        name = str(row["material_name"])
+        code_without_underscores = code.replace("_", "")
+        aliases = (
+            code,
+            code.casefold(),
+            code_without_underscores,
+            code_without_underscores.casefold(),
+        )
+        for alias in dict.fromkeys(aliases):
+            lookup.setdefault(alias, name)
+    return lookup

--- a/src/reports/shift_report/renderer.py
+++ b/src/reports/shift_report/renderer.py
@@ -1,10 +1,29 @@
-"""Convert ShiftReportData to markdown tables for the Streamlit report view."""
+"""Structured presentation for shift reports."""
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
+from reports.rendering import (
+    ReportDocument,
+    ReportNote,
+    ReportSection,
+    document_from_markdown as generic_document_from_markdown,
+    document_to_markdown,
+    is_section_row,
+    markdown_table,
+    parse_markdown_table,
+)
 from reports.shift_report.data import ParamStats, ShiftReportData, TempRow
+
+SHIFT_SECTION_TITLES = (
+    "Fuel Rate",
+    "Parameters",
+    "Temperature Profile",
+    "Hearth Pad Temperature",
+    "Tapping Summary",
+    "Consumption",
+)
 
 
 def _v(val: Optional[float]) -> str:
@@ -19,19 +38,20 @@ def _ps(stats: ParamStats) -> tuple[str, str]:
     return _v(stats.mean), _v(stats.std)
 
 
-def _tr(row: TempRow) -> str:
-    return (
-        f"| {_v(row.q1)} | {_v(row.q2)} | {_v(row.q3)} | "
-        f"{_v(row.q4)} | {_v(row.spread_std)} |"
-    )
+def _temp_cells(row: TempRow) -> list[str]:
+    return [_v(row.q1), _v(row.q2), _v(row.q3), _v(row.q4), _v(row.spread_std)]
 
 
-def as_markdown(report: ShiftReportData, analysis: str = "") -> str:
-    """Render a full shift handover report as markdown."""
+def as_document(
+    report: ShiftReportData,
+    analysis: str = "",
+    *,
+    title: str = "",
+) -> ReportDocument:
+    """Render computed shift data as a structured report document."""
     r = report
     flags_text = "; ".join(r.status_flags) if r.status_flags else "None"
-
-    header = (
+    preamble = (
         "**SHIFT HANDOVER REPORT - BF2 EVONITH STEEL**\n"
         f"**Shift ID:** {r.shift_label} &nbsp;"
         f" **Period:** {r.shift_start_ist.strftime('%Y-%m-%d %H:%M')}"
@@ -40,14 +60,136 @@ def as_markdown(report: ShiftReportData, analysis: str = "") -> str:
         f"**Flags:** {flags_text}"
     )
 
-    fuel_rate_table = (
-        "| Fuel rate (kg/thm) | Coke rate (kg/thm) | "
-        "Nut Coke rate (kg/thm) | PCI rate (kg/thm) |\n"
-        "|---|---|---|---|\n"
-        f"| {_v(r.fuel_rate)} | {_v(r.coke_rate)} | "
-        f"{_v(r.nut_coke_rate)} | {_v(r.pci_rate)} |"
+    sections = (
+        ReportSection.from_rows(
+            "Fuel Rate",
+            [
+                "Fuel rate (kg/thm)",
+                "Coke rate (kg/thm)",
+                "Nut Coke rate (kg/thm)",
+                "PCI rate (kg/thm)",
+            ],
+            [[_v(r.fuel_rate), _v(r.coke_rate), _v(r.nut_coke_rate), _v(r.pci_rate)]],
+            placement="left",
+        ),
+        ReportSection.from_rows(
+            "Parameters",
+            ["Parameter", "UOM", "Value", "Std.Dev"],
+            _parameter_rows(r),
+            placement="left",
+        ),
+        ReportSection.from_rows(
+            "Temperature Profile",
+            ["Parameter", "Q1", "Q2", "Q3", "Q4", "Std.Dev"],
+            [
+                ["Uptake Temp (degC)", *_temp_cells(r.uptake)],
+                ["Skin flow", "-", "-", "-", "-", "-"],
+                ["Lower stack (degC)", *_temp_cells(r.lower_stack)],
+                ["Belly (degC)", *_temp_cells(r.belly)],
+                ["Bosh (degC)", *_temp_cells(r.bosh)],
+            ],
+        ),
+        ReportSection.from_rows(
+            "Hearth Pad Temperature",
+            ["Parameter", "4.3mtr A", "5.4mtr C", "5.7mtr C", "6.1mtr B"],
+            [
+                [
+                    "Hearth Pad Temp (degC)",
+                    _v(r.hearth_4_3_a),
+                    _v(r.hearth_5_4_c),
+                    _v(r.hearth_5_7_c),
+                    _v(r.hearth_6_1_b),
+                ]
+            ],
+        ),
+        ReportSection.from_rows(
+            "Tapping Summary",
+            [
+                "Total Taps (no's)",
+                "Tap Duration (mins)",
+                "Slag Duration (mins)",
+                "Slag Ratio (%)",
+                "Casting Rate (T/min)",
+            ],
+            [[_vi(r.total_taps), "-", "-", "-", "-"]],
+        ),
+        ReportSection.from_rows(
+            "Consumption",
+            [
+                "Coke (tons)",
+                "Nut coke (tons)",
+                "Ore (tons)",
+                "Flux (tons)",
+                "Sinter (tons)",
+                "Pellet (tons)",
+            ],
+            [
+                [
+                    _v(r.coke_t),
+                    _v(r.nut_coke_t),
+                    _v(r.ore_t),
+                    _v(r.flux_t),
+                    _v(r.sinter_t),
+                    _v(r.pellet_t),
+                ]
+            ],
+        ),
     )
 
+    notes = []
+    if r.used_materials:
+        notes.append(
+            ReportNote(
+                "\n".join(
+                    f"{category} : {materials}"
+                    for category, materials in r.used_materials.items()
+                ),
+                kind="material_usage",
+            )
+        )
+    if analysis.strip():
+        notes.append(ReportNote(f"**Shift Analysis**\n\n{analysis.strip()}", kind="analysis"))
+
+    return ReportDocument(
+        title=title,
+        pre_blocks=(preamble,),
+        sections=sections,
+        notes=tuple(notes),
+    )
+
+
+def as_markdown(report: ShiftReportData, analysis: str = "") -> str:
+    """Render a full shift handover report as markdown."""
+    return document_to_markdown(as_document(report, analysis))
+
+
+def document_from_markdown(title: str, summary_text: str) -> ReportDocument:
+    """Build a structured shift-report document from saved markdown."""
+    tables, pre, post = _normalize_shift_markdown_tables(summary_text)
+    document = generic_document_from_markdown(
+        title,
+        "\n\n".join([*pre, *tables, *post]),
+        table_titles=SHIFT_SECTION_TITLES,
+        default_left_count=2,
+    )
+    return ReportDocument(
+        title=document.title,
+        pre_blocks=document.pre_blocks,
+        sections=document.sections,
+        notes=tuple(_classify_shift_note(note) for note in document.notes),
+    )
+
+
+def _classify_shift_note(note: ReportNote) -> ReportNote:
+    first_line = note.text.strip().splitlines()[0] if note.text.strip() else ""
+    if first_line.startswith(("Flux :", "Ore :")):
+        return ReportNote(note.text, placement=note.placement, kind="material_usage")
+    if first_line == "**Shift Analysis**":
+        return ReportNote(note.text, placement=note.placement, kind="analysis")
+    return note
+
+
+def _parameter_rows(r: ShiftReportData) -> list[list[str]]:
     bv, bs = _ps(r.blast_volume)
     bt, bts = _ps(r.blast_temp)
     bp, bps = _ps(r.blast_pressure)
@@ -60,89 +202,188 @@ def as_markdown(report: ShiftReportData, analysis: str = "") -> str:
     of, ofs = _ps(r.o2_flow)
     oe, oes = _ps(r.o2_enrichment)
 
-    params_table = (
-        "| Parameter | UOM | Value | Std.Dev |\n"
-        "|---|---|---|---|\n"
-        "| **Production** | | | |\n"
-        f"| Production rate | t/hr | {_v(r.production_rate)} | - |\n"
-        f"| Theoretical Production | tons | {_v(r.theoretical_production)} | - |\n"
-        f"| Total Charges | no's | {_vi(r.total_charges)} | - |\n"
-        "| **Process Parameters** | | | |\n"
-        f"| Hot blast volume | Nm3/hr | {bv} | {bs} |\n"
-        f"| Hot blast temperature | degC | {bt} | {bts} |\n"
-        f"| Hot blast pressure | bar | {bp} | {bps} |\n"
-        f"| Furnace Top DP | bar | {top_dp} | {top_dps} |\n"
-        f"| Furnace Bottom DP | bar | {bottom_dp} | {bottom_dps} |\n"
-        f"| Furnace Total DP | bar | {total_dp} | {total_dps} |\n"
-        f"| Oxygen Flow | Nm3/hr | {of} | {ofs} |\n"
-        f"| Oxygen enrichment | % | {oe} | {oes} |\n"
-        f"| Permeability | - | {pe} | {pes} |\n"
-        f"| ETA CO | % | {ec} | {ecs} |\n"
-        f"| RAFT | degC | {ra} | {ras} |\n"
-        f"| Burden Moisture Input | kg/thm | {_v(r.burden_moisture_input)} | - |\n"
-        f"| Fines Input | kg/thm | {_v(r.fines_input)} | - |\n"
-        "| **Quality** | | | |\n"
-        f"| HM Si | % | {_v(r.hm_si)} | - |\n"
-        f"| HM S | % | {_v(r.hm_s)} | - |\n"
-        f"| HM Temperature | degC | {_v(r.hm_temp)} | - |\n"
-        f"| Slag Basicity | - | {_v(r.slag_basicity)} | - |\n"
-    )
-
-    temp_table = (
-        "| Parameter | Q1 | Q2 | Q3 | Q4 | Std.Dev |\n"
-        "|---|---|---|---|---|---|\n"
-        f"| Uptake Temp (degC) {_tr(r.uptake)}\n"
-        "| Skin flow | - | - | - | - | - |\n"
-        f"| Lower stack (degC) {_tr(r.lower_stack)}\n"
-        f"| Belly (degC) {_tr(r.belly)}\n"
-        f"| Bosh (degC) {_tr(r.bosh)}"
-    )
-
-    hearth_table = (
-        "| Parameter | 4.3mtr A | 5.4mtr C | 5.7mtr C | 6.1mtr B |\n"
-        "|---|---|---|---|---|\n"
-        f"| Hearth Pad Temp (degC)"
-        f" | {_v(r.hearth_4_3_a)}"
-        f" | {_v(r.hearth_5_4_c)}"
-        f" | {_v(r.hearth_5_7_c)}"
-        f" | {_v(r.hearth_6_1_b)} |"
-    )
-
-    tapping_table = (
-        "| Total Taps (no's) | Tap Duration (mins) | "
-        "Slag Duration (mins) | Slag Ratio (%) | Casting Rate (T/min) |\n"
-        "|---|---|---|---|---|\n"
-        f"| {_vi(r.total_taps)} | - | - | - | - |"
-    )
-
-    consumption_table = (
-        "| Coke (tons) | Nut coke (tons) | Ore (tons) | Flux (tons) | "
-        "Sinter (tons) | Pellet (tons) |\n"
-        "|---|---|---|---|---|---|\n"
-        f"| {_v(r.coke_t)} | {_v(r.nut_coke_t)} | {_v(r.ore_t)} | "
-        f"{_v(r.flux_t)} | {_v(r.sinter_t)} | {_v(r.pellet_t)} |"
-    )
-
-    material_usage_note = ""
-    if r.used_materials:
-        material_usage_note = "\n\n".join(
-            f"{category} : {materials}"
-            for category, materials in r.used_materials.items()
-        )
-
-    parts = [
-        header,
-        fuel_rate_table,
-        params_table,
-        temp_table,
-        hearth_table,
-        tapping_table,
-        consumption_table,
+    return [
+        ["**Production**", "", "", ""],
+        ["Production rate", "t/hr", _v(r.production_rate), "-"],
+        ["Theoretical Production", "tons", _v(r.theoretical_production), "-"],
+        ["Total Charges", "no's", _vi(r.total_charges), "-"],
+        ["**Process Parameters**", "", "", ""],
+        ["Hot blast volume", "Nm3/hr", bv, bs],
+        ["Hot blast temperature", "degC", bt, bts],
+        ["Hot blast pressure", "bar", bp, bps],
+        ["Furnace Top DP", "bar", top_dp, top_dps],
+        ["Furnace Bottom DP", "bar", bottom_dp, bottom_dps],
+        ["Furnace Total DP", "bar", total_dp, total_dps],
+        ["Oxygen Flow", "Nm3/hr", of, ofs],
+        ["Oxygen enrichment", "%", oe, oes],
+        ["Permeability", "-", pe, pes],
+        ["ETA CO", "%", ec, ecs],
+        ["RAFT", "degC", ra, ras],
+        ["Burden Moisture Input", "kg/thm", _v(r.burden_moisture_input), "-"],
+        ["Fines Input", "kg/thm", _v(r.fines_input), "-"],
+        ["**Quality**", "", "", ""],
+        ["HM Si", "%", _v(r.hm_si), "-"],
+        ["HM S", "%", _v(r.hm_s), "-"],
+        ["HM Temperature", "degC", _v(r.hm_temp), "-"],
+        ["Slag Basicity", "-", _v(r.slag_basicity), "-"],
     ]
-    if material_usage_note:
-        parts.append(material_usage_note)
 
-    if analysis.strip():
-        parts.append(f"**Shift Analysis**\n\n{analysis.strip()}")
 
-    return "\n\n".join(parts)
+def _normalize_shift_markdown_tables(
+    summary_text: str,
+) -> tuple[list[str], list[str], list[str]]:
+    from reports.rendering import split_markdown_blocks
+
+    tables, pre, post = split_markdown_blocks(summary_text)
+    normalized = [_normalize_tapping_table(table) for table in tables]
+    if len(normalized) < 2:
+        return normalized, pre, post
+
+    first_headers, first_rows = parse_markdown_table(normalized[0])
+    previous_split = _split_previous_consumption_table(first_headers, first_rows)
+    if previous_split is not None:
+        fuel_rate_table, consumption_table = previous_split
+        return [fuel_rate_table, *normalized[1:], consumption_table], pre, post
+
+    second_headers, second_rows = parse_markdown_table(normalized[1])
+    if first_headers != ["Parameter", "UOM", "Value"]:
+        return normalized, pre, post
+    if second_headers != ["Parameter", "UOM", "Value", "Std.Dev"]:
+        return normalized, pre, post
+
+    section_names = {row[0] for row in first_rows if is_section_row(row)}
+    if not {"Consumption", "Quality"}.issubset(section_names):
+        return normalized, pre, post
+
+    sections = _legacy_shift_sections(first_rows)
+    consumption_lookup = {
+        row[0].lower(): row[2]
+        for row in sections.get("Consumption", [])
+        if len(row) >= 3
+    }
+    params_table = _legacy_parameter_table(sections, second_rows)
+    return [
+        _fuel_rate_table(consumption_lookup),
+        params_table,
+        *normalized[2:],
+        _consumption_table(consumption_lookup),
+    ], pre, post
+
+
+def _legacy_parameter_table(
+    sections: dict[str, list[list[str]]],
+    second_rows: Sequence[Sequence[str]],
+) -> str:
+    parameter_rows = [["**Production**", "", "", ""]]
+    parameter_rows.extend(
+        [row[0], row[1], row[2], "-"]
+        for row in sections.get("Production", [])
+        if len(row) >= 3
+    )
+    parameter_rows.append(["**Quality**", "", "", ""])
+    parameter_rows.extend(
+        [row[0], row[1], row[2], "-"]
+        for row in sections.get("Quality", [])
+        if len(row) >= 3
+    )
+    parameter_rows.append(["**Process Parameters**", "", "", ""])
+    parameter_rows.extend([list(row) for row in second_rows])
+    return markdown_table(["Parameter", "UOM", "Value", "Std.Dev"], parameter_rows)
+
+
+def _split_previous_consumption_table(
+    headers: list[str],
+    rows: list[list[str]],
+) -> tuple[str, str] | None:
+    previous_headers = [
+        "Coke (tons)",
+        "Nut coke (tons)",
+        "Ore (tons)",
+        "Flux (tons)",
+        "Sinter (tons)",
+        "Pellet (tons)",
+        "Fuel rate (kg/thm)",
+        "Coke rate (kg/thm)",
+        "Nut Coke rate (kg/thm)",
+        "PCI rate (kg/thm)",
+    ]
+    if headers != previous_headers or not rows:
+        return None
+
+    values = {header.lower(): value for header, value in zip(headers, rows[0])}
+    return _fuel_rate_table(values), _consumption_table(values)
+
+
+def _fuel_rate_table(values: dict[str, str]) -> str:
+    headers = [
+        "Fuel rate (kg/thm)",
+        "Coke rate (kg/thm)",
+        "Nut Coke rate (kg/thm)",
+        "PCI rate (kg/thm)",
+    ]
+    keys = ["fuel rate", "coke rate", "nut coke rate", "pci rate"]
+    return markdown_table(
+        headers,
+        [[values.get(header.lower(), values.get(key, "-")) for header, key in zip(headers, keys)]],
+    )
+
+
+def _consumption_table(values: dict[str, str]) -> str:
+    headers = [
+        "Coke (tons)",
+        "Nut coke (tons)",
+        "Ore (tons)",
+        "Flux (tons)",
+        "Sinter (tons)",
+        "Pellet (tons)",
+    ]
+    keys = ["coke", "nut coke", "ore", "flux", "sinter", "pellet"]
+    return markdown_table(
+        headers,
+        [[values.get(header.lower(), values.get(key, "-")) for header, key in zip(headers, keys)]],
+    )
+
+
+def _normalize_tapping_table(table: str) -> str:
+    headers, rows = parse_markdown_table(table)
+    if headers != ["Parameter", "UOM", "Value"]:
+        return table
+
+    values = {row[0].lower(): row[2] for row in rows if len(row) >= 3}
+    if "total taps" not in values:
+        return table
+
+    return markdown_table(
+        [
+            "Total Taps (no's)",
+            "Tap Duration (mins)",
+            "Slag Duration (mins)",
+            "Slag Ratio (%)",
+            "Casting Rate (T/min)",
+        ],
+        [
+            [
+                values.get("total taps", "-"),
+                values.get("tap duration", "-"),
+                values.get("slag duration", "-"),
+                values.get("slag ratio", "-"),
+                values.get("casting rate", "-"),
+            ]
+        ],
+    )
+
+
+def _legacy_shift_sections(rows: list[list[str]]) -> dict[str, list[list[str]]]:
+    sections: dict[str, list[list[str]]] = {
+        "Production": [],
+        "Consumption": [],
+        "Quality": [],
+    }
+    current = "Production"
+    for row in rows:
+        if is_section_row(row):
+            current = row[0]
+            sections.setdefault(current, [])
+            continue
+        sections.setdefault(current, []).append(row)
+    return sections

--- a/src/reports/shift_report/service.py
+++ b/src/reports/shift_report/service.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from datetime import date
+import logging
 from typing import Literal, Optional
 
+from reports.rendering import ReportDocument, document_to_markdown
 from reports.shift_report.analyser import ShiftAnalyser
 from reports.shift_report.builder import ShiftBuilder
 from reports.shift_report.data import ShiftReportData
 from reports.shift_report.fetcher import ShiftFetcher
-from reports.shift_report.renderer import as_markdown
+from reports.shift_report.renderer import as_document
 from utils.shift_windows import previous_shift
+
+logger = logging.getLogger(__name__)
 
 
 class ShiftReportService:
@@ -57,6 +61,21 @@ class ShiftReportService:
         Returns:
              - return: tuple[ShiftReportData, str] - Report data and markdown.
         """
+        report_data, document = self.generate_document(
+            shift_date,
+            shift_label,
+            include_analysis=include_analysis,
+        )
+        return report_data, document_to_markdown(document)
+
+    def generate_document(
+        self,
+        shift_date: date,
+        shift_label: Literal["A", "B", "C"],
+        *,
+        include_analysis: bool = True,
+    ) -> tuple[ShiftReportData, ReportDocument]:
+        """Fetch data, build metrics, and return a structured report document."""
         raw = self._fetcher.fetch(shift_date=shift_date, shift_label=shift_label)
         current = self._builder.build(raw)
 
@@ -69,6 +88,7 @@ class ShiftReportService:
                 )
                 previous = self._builder.build(prev_raw)
             except Exception:
+                logger.warning("Unable to build previous shift for analysis", exc_info=True)
                 previous = None
 
         analysis = ""
@@ -76,6 +96,8 @@ class ShiftReportService:
             try:
                 analysis = self._analyser.analyse(current, previous)
             except Exception:
+                logger.warning("Shift report analysis failed", exc_info=True)
                 analysis = ""
 
-        return current, as_markdown(current, analysis)
+        title = f"Live Report ({shift_date:%Y-%m-%d}_SHIFT_{shift_label})"
+        return current, as_document(current, analysis, title=title)

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -7,27 +7,25 @@ import re
 
 import streamlit as st
 
-_BLOCK_RE = re.compile(r"\n{2,}")
-_BOLD_RE = re.compile(r"\*\*(.*?)\*\*")
-_BR_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+from reports.rendering import (
+    ReportDocument,
+    ReportNote,
+    ReportSection,
+    clean_inline,
+    document_from_markdown,
+    markdown_table,
+)
+
 _SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
-_TABLE_SEP = re.compile(r"^\|[-:| ]+\|", re.MULTILINE)
 _SHIFT_REPORT_TITLE_RE = re.compile(
     r"\((\d{4}-\d{2}-\d{2})_SHIFT_([A-Za-z0-9]+)\)"
 )
-_TABLE_TITLES = (
-    "Fuel Rate",
-    "Parameters",
-    "Temperature Profile",
-    "Hearth Pad Temperature",
-    "Tapping Summary",
-    "Consumption",
-)
-_REPORT_TABLE_IMAGE_STYLE_VERSION = 15
+_HEADER_UOM_RE = re.compile(r"^(.+?)\s+(\([^)]{1,24}\))$")
+_REPORT_TABLE_IMAGE_STYLE_VERSION = 16
 
 
 class ReportTableImageRenderer:
-    """Render shift-report markdown tables into one two-column PNG."""
+    """Render a structured report document into one PNG."""
 
     image_width_px = 3840
     image_height_px = 2160
@@ -38,9 +36,8 @@ class ReportTableImageRenderer:
     dense_body_size = 18
     cell_padding = 0.075
     right_cell_padding = 0.12
-    right_table_hspace = 0.18
-    top_table_hspace = 0.12
     top_cell_padding = 0.1
+    stack_hspace = 0.18
     content_top = 0.935
     section_title_pad = 4
     titled_table_height = 0.96
@@ -50,28 +47,17 @@ class ReportTableImageRenderer:
     line = "#d8dee8"
     section = "#eef4fb"
     stripe = "#f8fafc"
-    image_header_breaks = {
-        "Fuel rate (kg/thm)": "Fuel rate\n(kg/thm)",
-        "Coke rate (kg/thm)": "Coke rate\n(kg/thm)",
-        "Nut Coke rate (kg/thm)": "Nut Coke rate\n(kg/thm)",
-        "PCI rate (kg/thm)": "PCI rate\n(kg/thm)",
-        "Total Taps (no's)": "Total Taps\n(no's)",
-        "Tap Duration (mins)": "Tap Duration\n(mins)",
-        "Slag Duration (mins)": "Slag Duration\n(mins)",
-        "Slag Ratio (%)": "Slag Ratio\n(%)",
-        "Casting Rate (T/min)": "Casting Rate\n(T/min)",
-        "Coke (tons)": "Coke\n(tons)",
-        "Nut coke (tons)": "Nut coke\n(tons)",
-        "Ore (tons)": "Ore\n(tons)",
-        "Flux (tons)": "Flux\n(tons)",
-        "Sinter (tons)": "Sinter\n(tons)",
-        "Pellet (tons)": "Pellet\n(tons)",
-    }
 
-    def __init__(self, title: str, summary_text: str) -> None:
-        self.title = self._image_title(title)
-        self.post = self.split_blocks(summary_text)[2]
-        self.tables = self._tables(summary_text)
+    def __init__(
+        self,
+        document_or_title: ReportDocument | str,
+        summary_text: str | None = None,
+    ) -> None:
+        self.document = (
+            document_or_title
+            if isinstance(document_or_title, ReportDocument)
+            else document_from_markdown(str(document_or_title), summary_text or "")
+        )
 
     @staticmethod
     def _image_title(title: str) -> str:
@@ -80,29 +66,13 @@ class ReportTableImageRenderer:
             return f"{match.group(1)} {match.group(2)} SHIFT REPORT"
         return title
 
-    @staticmethod
-    def split_blocks(summary_text: str) -> tuple[list[str], list[str], list[str]]:
-        tables, pre, post, seen_table = [], [], [], False
-        for block in filter(
-            None, (b.strip() for b in _BLOCK_RE.split(summary_text.strip()))
-        ):
-            if _TABLE_SEP.search(block):
-                tables.append(block)
-                seen_table = True
-            elif seen_table:
-                post.append(block)
-            else:
-                pre.append(block)
-        return tables, pre, post
-
     def render(self) -> bytes:
-        if not self.tables:
+        if not self.document.sections:
             return b""
 
         from matplotlib.backends.backend_agg import FigureCanvasAgg
         from matplotlib.figure import Figure
 
-        two_col = len(self.tables) > 1
         fig = Figure(
             figsize=(
                 self.image_width_px / self.dpi,
@@ -113,7 +83,7 @@ class ReportTableImageRenderer:
         )
         FigureCanvasAgg(fig)
         fig.suptitle(
-            self.title,
+            self._image_title(self.document.title),
             x=0.02,
             y=0.995,
             ha="left",
@@ -121,9 +91,18 @@ class ReportTableImageRenderer:
             fontweight="bold",
             color=self.text,
         )
-        material_note = self._material_note_text()
 
-        if len(self.tables) >= 3:
+        left_sections = [
+            section for section in self.document.sections if section.placement == "left"
+        ]
+        right_sections = [
+            section for section in self.document.sections if section.placement != "left"
+        ]
+        image_notes = [
+            note for note in self.document.notes if note.kind == "material_usage"
+        ]
+
+        if left_sections and right_sections:
             grid = fig.add_gridspec(
                 1,
                 2,
@@ -134,72 +113,19 @@ class ReportTableImageRenderer:
                 top=self.content_top,
                 bottom=0.055,
             )
-            left = grid[0, 0].subgridspec(
-                2,
-                1,
-                height_ratios=[0.72, 4.28],
-                hspace=self.top_table_hspace,
+            self._draw_stack(
+                fig,
+                grid[0, 0],
+                left_sections,
+                first_padding=self.top_cell_padding,
             )
-            self._draw_table(
-                fig.add_subplot(left[0, 0]),
-                self.tables[0],
-                cell_padding=self.top_cell_padding,
+            self._draw_stack(
+                fig,
+                grid[0, 1],
+                right_sections,
+                image_notes,
+                section_padding=self.right_cell_padding,
             )
-            self._draw_table(fig.add_subplot(left[1, 0]), self.tables[1])
-            right_tables = self.tables[2:]
-            right_count = len(right_tables) + int(bool(material_note))
-            right = grid[0, 1].subgridspec(
-                right_count,
-                1,
-                hspace=self.right_table_hspace,
-                height_ratios=[
-                    *[self._table_weight(table) for table in right_tables],
-                    *([0.9] if material_note else []),
-                ],
-            )
-            for index, table in enumerate(right_tables):
-                self._draw_table(
-                    fig.add_subplot(right[index, 0]),
-                    table,
-                    cell_padding=self.right_cell_padding,
-                )
-            if material_note:
-                self._draw_note(
-                    fig.add_subplot(right[len(right_tables), 0]), material_note
-                )
-        elif two_col:
-            grid = fig.add_gridspec(
-                1,
-                2,
-                width_ratios=[1.05, 1],
-                wspace=0.08,
-                left=0.035,
-                right=0.985,
-                top=self.content_top,
-                bottom=0.055,
-            )
-            self._draw_table(fig.add_subplot(grid[0, 0]), self.tables[0])
-            right_tables = self.tables[1:]
-            right_count = len(right_tables) + int(bool(material_note))
-            right = grid[0, 1].subgridspec(
-                right_count,
-                1,
-                hspace=self.right_table_hspace,
-                height_ratios=[
-                    *[self._table_weight(table) for table in right_tables],
-                    *([0.9] if material_note else []),
-                ],
-            )
-            for index, table in enumerate(right_tables):
-                self._draw_table(
-                    fig.add_subplot(right[index, 0]),
-                    table,
-                    cell_padding=self.right_cell_padding,
-                )
-            if material_note:
-                self._draw_note(
-                    fig.add_subplot(right[len(right_tables), 0]), material_note
-                )
         else:
             grid = fig.add_gridspec(
                 1,
@@ -209,249 +135,82 @@ class ReportTableImageRenderer:
                 top=self.content_top,
                 bottom=0.055,
             )
-            self._draw_table(fig.add_subplot(grid[0, 0]), self.tables[0])
+            self._draw_stack(
+                fig,
+                grid[0, 0],
+                left_sections or right_sections,
+                image_notes,
+                first_padding=self.top_cell_padding,
+            )
 
         output = BytesIO()
         fig.savefig(output, format="png", dpi=self.dpi)
         return output.getvalue()
 
-    def _tables(
-        self, summary_text: str
-    ) -> list[tuple[str, list[str], list[list[str]]]]:
-        tables = []
-        for index, markdown in enumerate(self.table_blocks(summary_text)):
-            headers, rows = self._parse_table(markdown)
-            if headers:
-                title = (
-                    _TABLE_TITLES[index]
-                    if index < len(_TABLE_TITLES)
-                    else f"Report Table {index + 1}"
-                )
-                tables.append((title, headers, rows))
-        return tables
-
-    @classmethod
-    def table_blocks(cls, summary_text: str) -> list[str]:
-        return cls._normalize_table_blocks(cls.split_blocks(summary_text)[0])
-
-    @classmethod
-    def _normalize_table_blocks(cls, tables: list[str]) -> list[str]:
-        tables = [cls._normalize_tapping_table(table) for table in tables]
-        if len(tables) < 2:
-            return tables
-
-        first_headers, first_rows = cls._parse_table(tables[0])
-        previous_split = cls._split_previous_consumption_table(first_headers, first_rows)
-        if previous_split is not None:
-            fuel_rate_table, consumption_table = previous_split
-            return [fuel_rate_table, *tables[1:], consumption_table]
-
-        second_headers, second_rows = cls._parse_table(tables[1])
-        if first_headers != ["Parameter", "UOM", "Value"]:
-            return tables
-        if second_headers != ["Parameter", "UOM", "Value", "Std.Dev"]:
-            return tables
-
-        section_names = {row[0] for row in first_rows if cls._is_section(row)}
-        if not {"Consumption", "Quality"}.issubset(section_names):
-            return tables
-
-        sections = cls._legacy_shift_sections(first_rows)
-        consumption_lookup = {
-            row[0].lower(): row[2]
-            for row in sections.get("Consumption", [])
-            if len(row) >= 3
-        }
-        fuel_rate_table = cls._fuel_rate_table(consumption_lookup)
-        consumption_table = cls._consumption_table(consumption_lookup)
-
-        parameter_rows = [["**Production**", "", "", ""]]
-        parameter_rows.extend(
-            [row[0], row[1], row[2], "-"]
-            for row in sections.get("Production", [])
-            if len(row) >= 3
-        )
-        parameter_rows.append(["**Quality**", "", "", ""])
-        parameter_rows.extend(
-            [row[0], row[1], row[2], "-"]
-            for row in sections.get("Quality", [])
-            if len(row) >= 3
-        )
-        parameter_rows.append(["**Process Parameters**", "", "", ""])
-        parameter_rows.extend(second_rows)
-        params_table = cls._markdown_table(
-            ["Parameter", "UOM", "Value", "Std.Dev"],
-            parameter_rows,
-        )
-        return [fuel_rate_table, params_table, *tables[2:], consumption_table]
-
-    @classmethod
-    def _split_previous_consumption_table(
-        cls,
-        headers: list[str],
-        rows: list[list[str]],
-    ) -> tuple[str, str] | None:
-        previous_headers = [
-            "Coke (tons)",
-            "Nut coke (tons)",
-            "Ore (tons)",
-            "Flux (tons)",
-            "Sinter (tons)",
-            "Pellet (tons)",
-            "Fuel rate (kg/thm)",
-            "Coke rate (kg/thm)",
-            "Nut Coke rate (kg/thm)",
-            "PCI rate (kg/thm)",
-        ]
-        if headers != previous_headers or not rows:
-            return None
-
-        values = {header.lower(): value for header, value in zip(headers, rows[0])}
-        return cls._fuel_rate_table(values), cls._consumption_table(values)
-
-    @classmethod
-    def _fuel_rate_table(cls, values: dict[str, str]) -> str:
-        headers = [
-            "Fuel rate (kg/thm)",
-            "Coke rate (kg/thm)",
-            "Nut Coke rate (kg/thm)",
-            "PCI rate (kg/thm)",
-        ]
-        keys = ["fuel rate", "coke rate", "nut coke rate", "pci rate"]
-        return cls._markdown_table(
-            headers,
-            [
-                [
-                    values.get(header.lower(), values.get(key, "-"))
-                    for header, key in zip(headers, keys)
-                ]
+    def _draw_stack(
+        self,
+        fig,
+        grid_spec,
+        sections: list[ReportSection],
+        notes: list[ReportNote] | None = None,
+        section_padding: float | None = None,
+        first_padding: float | None = None,
+    ) -> None:
+        notes = notes or []
+        count = len(sections) + len(notes)
+        stack = grid_spec.subgridspec(
+            count,
+            1,
+            hspace=self.stack_hspace,
+            height_ratios=[
+                *[self._section_weight(section) for section in sections],
+                *([0.9] * len(notes)),
             ],
         )
+        for index, section in enumerate(sections):
+            padding = first_padding if index == 0 and first_padding is not None else section_padding
+            self._draw_table(fig.add_subplot(stack[index, 0]), section, padding=padding)
 
-    @classmethod
-    def _consumption_table(cls, values: dict[str, str]) -> str:
-        headers = [
-            "Coke (tons)",
-            "Nut coke (tons)",
-            "Ore (tons)",
-            "Flux (tons)",
-            "Sinter (tons)",
-            "Pellet (tons)",
-        ]
-        material_keys = [
-            "coke",
-            "nut coke",
-            "ore",
-            "flux",
-            "sinter",
-            "pellet",
-        ]
-        return cls._markdown_table(
-            headers,
-            [
-                [
-                    values.get(header.lower(), values.get(key, "-"))
-                    for header, key in zip(headers, material_keys)
-                ]
-            ],
-        )
-
-    @classmethod
-    def _normalize_tapping_table(cls, table: str) -> str:
-        headers, rows = cls._parse_table(table)
-        if headers != ["Parameter", "UOM", "Value"]:
-            return table
-
-        values = {row[0].lower(): row[2] for row in rows if len(row) >= 3}
-        if "total taps" not in values:
-            return table
-
-        return cls._markdown_table(
-            [
-                "Total Taps (no's)",
-                "Tap Duration (mins)",
-                "Slag Duration (mins)",
-                "Slag Ratio (%)",
-                "Casting Rate (T/min)",
-            ],
-            [
-                [
-                    values.get("total taps", "-"),
-                    values.get("tap duration", "-"),
-                    values.get("slag duration", "-"),
-                    values.get("slag ratio", "-"),
-                    values.get("casting rate", "-"),
-                ]
-            ],
-        )
-
-    @classmethod
-    def _legacy_shift_sections(cls, rows: list[list[str]]) -> dict[str, list[list[str]]]:
-        sections: dict[str, list[list[str]]] = {
-            "Production": [],
-            "Consumption": [],
-            "Quality": [],
-        }
-        current = "Production"
-        for row in rows:
-            if cls._is_section(row):
-                current = row[0]
-                sections.setdefault(current, [])
-                continue
-            sections.setdefault(current, []).append(row)
-        return sections
+        for offset, note in enumerate(notes, start=len(sections)):
+            self._draw_note(fig.add_subplot(stack[offset, 0]), note.text)
 
     @staticmethod
-    def _markdown_table(headers: list[str], rows: list[list[str]]) -> str:
-        width = len(headers)
-        lines = [
-            "| " + " | ".join(headers) + " |",
-            "|" + "|".join(["---"] * width) + "|",
-        ]
-        for row in rows:
-            cells = (row + [""] * width)[:width]
-            lines.append("| " + " | ".join(cells) + " |")
-        return "\n".join(lines)
-
-    @staticmethod
-    def _table_weight(table: tuple[str, list[str], list[list[str]]]) -> int:
-        return max(4, len(table[2]) + 2)
+    def _section_weight(section: ReportSection) -> int:
+        return max(4, len(section.rows) + 2)
 
     def _draw_table(
         self,
         ax,
-        table: tuple[str, list[str], list[list[str]]],
+        section: ReportSection,
         *,
-        cell_padding: float | None = None,
+        padding: float | None = None,
     ) -> None:
-        title, headers, rows = table
-        padding = self.cell_padding if cell_padding is None else cell_padding
+        cell_padding = self.cell_padding if padding is None else padding
         ax.set_axis_off()
-        if title:
-            ax.set_title(
-                title,
-                loc="left",
-                pad=self.section_title_pad,
-                fontsize=self.section_title_size,
-                fontweight="bold",
-                color=self.text,
-            )
+        ax.set_title(
+            section.title,
+            loc="left",
+            pad=self.section_title_pad,
+            fontsize=self.section_title_size,
+            fontweight="bold",
+            color=self.text,
+        )
         artist = ax.table(
-            cellText=rows or [[""] * len(headers)],
-            colLabels=[self._image_header(header) for header in headers],
+            cellText=section.rows or [[""] * len(section.headers)],
+            colLabels=[self._image_header(header) for header in section.headers],
             cellLoc="left",
             colLoc="left",
-            bbox=[0, 0, 1, self.titled_table_height if title else 1],
+            bbox=[0, 0, 1, self.titled_table_height],
         )
         artist.auto_set_font_size(False)
         artist.set_fontsize(
-            self.dense_body_size if len(headers) > 4 else self.body_size
+            self.dense_body_size if len(section.headers) > 4 else self.body_size
         )
-        artist.auto_set_column_width(col=list(range(len(headers))))
+        artist.auto_set_column_width(col=list(range(len(section.headers))))
 
         for (row_index, _), cell in artist.get_celld().items():
             cell.set_edgecolor(self.line)
-            cell.PAD = padding
+            cell.PAD = cell_padding
             text = cell.get_text()
             text.set_ha("left")
             text.set_va("center")
@@ -462,8 +221,8 @@ class ReportTableImageRenderer:
                 text.set_fontweight("bold")
                 continue
 
-            source = rows[row_index - 1] if rows else []
-            if self._is_section(source):
+            row = section.rows[row_index - 1] if section.rows else ()
+            if self._is_section_row(row):
                 cell.set_facecolor(self.section)
                 text.set_color(self.text)
                 text.set_fontweight("bold")
@@ -476,7 +235,7 @@ class ReportTableImageRenderer:
         ax.text(
             0,
             0.95,
-            text,
+            clean_inline(text),
             transform=ax.transAxes,
             ha="left",
             va="top",
@@ -485,128 +244,74 @@ class ReportTableImageRenderer:
             wrap=True,
         )
 
-    def _material_note_text(self) -> str:
-        lines: list[str] = []
-        for block in self.post:
-            for line in block.splitlines():
-                clean = _BOLD_RE.sub(r"\1", _BR_RE.sub(" ", line)).strip()
-                if clean.startswith(("Flux :", "Ore :")):
-                    lines.append(clean)
-        return "\n".join(lines)
-
     @staticmethod
     def _image_header(header: str) -> str:
-        return ReportTableImageRenderer.image_header_breaks.get(header, header)
+        match = _HEADER_UOM_RE.fullmatch(header)
+        if match:
+            return f"{match.group(1)}\n{match.group(2)}"
+        return header
 
     @staticmethod
-    def _parse_table(markdown: str) -> tuple[list[str], list[list[str]]]:
-        lines = [line for line in markdown.splitlines() if line.strip().startswith("|")]
-        sep_idx = next(
-            (
-                idx
-                for idx, line in enumerate(lines)
-                if ReportTableImageRenderer._is_separator(line)
-            ),
-            -1,
-        )
-        if sep_idx <= 0:
-            return [], []
-        headers = ReportTableImageRenderer._cells(lines[sep_idx - 1])
-        width = len(headers)
-        rows = [
-            (ReportTableImageRenderer._cells(line) + [""] * width)[:width]
-            for line in lines[sep_idx + 1 :]
-            if not ReportTableImageRenderer._is_separator(line)
-        ]
-        return headers, rows
-
-    @staticmethod
-    def _cells(row: str) -> list[str]:
-        return [
-            _BOLD_RE.sub(
-                r"\1", _BR_RE.sub(" ", cell.strip()).replace("&nbsp;", " ")
-            ).strip()
-            for cell in row.strip().strip("|").split("|")
-        ]
-
-    @staticmethod
-    def _is_separator(row: str) -> bool:
-        cells = ReportTableImageRenderer._cells(row)
-        return bool(cells) and all(re.fullmatch(r":?-{3,}:?", cell) for cell in cells)
-
-    @staticmethod
-    def _is_section(row: list[str]) -> bool:
+    def _is_section_row(row: tuple[str, ...]) -> bool:
         return bool(row) and bool(row[0]) and all(not cell for cell in row[1:])
 
 
 class ReportView:
-    """Streamlit view for shift-report markdown."""
+    """Streamlit view for structured reports."""
 
-    def __init__(self, title: str, summary_text: str) -> None:
-        self.title = title
-        self.summary_text = summary_text
-        tables, self.pre, self.post = ReportTableImageRenderer.split_blocks(
-            summary_text
-        )
-        self.tables = ReportTableImageRenderer._normalize_table_blocks(tables)
+    def __init__(self, document: ReportDocument) -> None:
+        self.document = document
 
     def render(self) -> None:
-        st.subheader(self.title)
-        if self.pre:
-            st.markdown("\n\n".join(self.pre))
-        post_rendered = False
-        if len(self.tables) >= 3:
+        st.subheader(self.document.title)
+        if self.document.pre_blocks:
+            st.markdown("\n\n".join(self.document.pre_blocks))
+
+        left_sections = [
+            section for section in self.document.sections if section.placement == "left"
+        ]
+        right_sections = [
+            section for section in self.document.sections if section.placement != "left"
+        ]
+        right_notes = [
+            note for note in self.document.notes if note.placement != "left"
+        ]
+
+        if left_sections and right_sections:
             left, right = st.columns([52, 48])
             with left:
-                self._render_table(0, self.tables[0])
-                self._render_table(1, self.tables[1])
+                self._render_sections(left_sections)
             with right:
-                for index, table in enumerate(self.tables[2:], start=2):
-                    self._render_table(index, table)
-                if self.post:
-                    st.markdown("\n\n".join(self.post))
-                    post_rendered = True
-        elif len(self.tables) >= 2:
-            left, right = st.columns([52, 48])
-            with left:
-                self._render_table(0, self.tables[0])
-            with right:
-                for index, table in enumerate(self.tables[1:], start=1):
-                    self._render_table(index, table)
-                if self.post:
-                    st.markdown("\n\n".join(self.post))
-                    post_rendered = True
-        elif self.tables:
-            self._render_table(0, self.tables[0])
-        if self.post and not post_rendered:
-            st.markdown("\n\n".join(self.post))
+                self._render_sections(right_sections)
+                self._render_notes(right_notes)
+        else:
+            self._render_sections(left_sections or right_sections)
+            self._render_notes(self.document.notes)
+
         self._download_button()
 
     @staticmethod
-    def _render_table(index: int, markdown: str) -> None:
-        title = (
-            _TABLE_TITLES[index]
-            if index < len(_TABLE_TITLES)
-            else f"Report Table {index + 1}"
-        )
-        if title:
-            st.markdown(f"**{title}**")
-        st.markdown(_BR_RE.sub(" ", markdown))
+    def _render_sections(sections: list[ReportSection]) -> None:
+        for section in sections:
+            st.markdown(f"**{section.title}**")
+            st.markdown(markdown_table(section.headers, section.rows))
+
+    @staticmethod
+    def _render_notes(notes: list[ReportNote] | tuple[ReportNote, ...]) -> None:
+        for note in notes:
+            text = note.text.replace("\n", "  \n") if note.kind == "material_usage" else note.text
+            st.markdown(text)
 
     def _download_button(self) -> None:
-        image = _report_tables_png(
-            self.summary_text,
-            self.title,
-            _REPORT_TABLE_IMAGE_STYLE_VERSION,
-        )
+        image = _report_document_png(self.document, _REPORT_TABLE_IMAGE_STYLE_VERSION)
         if image:
             st.download_button(
                 "Download Report",
                 data=image,
-                file_name=f"{_safe_filename(self.title)}_tables.png",
+                file_name=f"{_safe_filename(self.document.title)}_tables.png",
                 mime="image/png",
                 use_container_width=True,
-                key=f"download_report_tables_png_{_safe_filename(self.title)}",
+                key=f"download_report_tables_png_{_safe_filename(self.document.title)}",
             )
 
 
@@ -615,13 +320,31 @@ def show_shift_summary(title: str, text: str) -> None:
     st.text_area(label="", value=text, height=250)
 
 
+def show_report_document(document: ReportDocument) -> None:
+    ReportView(document).render()
+
+
+def show_report(title: str, summary_text: str) -> None:
+    show_report_document(document_from_markdown(title, summary_text))
+
+
 def _safe_filename(value: str) -> str:
     return _SAFE_NAME_RE.sub("_", value.strip()).strip("_").lower() or "report"
 
 
 def _extract_report_tables(summary_text: str) -> tuple[list[str], list[str], list[str]]:
-    tables, pre, post = ReportTableImageRenderer.split_blocks(summary_text)
-    return ReportTableImageRenderer._normalize_table_blocks(tables), pre, post
+    document = document_from_markdown("", summary_text)
+    tables = [markdown_table(section.headers, section.rows) for section in document.sections]
+    return tables, list(document.pre_blocks), [note.text for note in document.notes]
+
+
+@st.cache_data(show_spinner=False)
+def _report_document_png(
+    document: ReportDocument,
+    style_version: int = _REPORT_TABLE_IMAGE_STYLE_VERSION,
+) -> bytes:
+    del style_version
+    return ReportTableImageRenderer(document).render()
 
 
 @st.cache_data(show_spinner=False)
@@ -632,7 +355,3 @@ def _report_tables_png(
 ) -> bytes:
     del style_version
     return ReportTableImageRenderer(report_title, summary_text).render()
-
-
-def show_report(title: str, summary_text: str) -> None:
-    ReportView(title, summary_text).render()

--- a/src/ui/furnacemind/reports.py
+++ b/src/ui/furnacemind/reports.py
@@ -4,16 +4,23 @@ from datetime import date
 
 import streamlit as st
 
-from ui.components import show_report
+from reports.rendering import ReportDocument, document_to_markdown
+from reports.shift_report.renderer import document_from_markdown
+from ui.components import show_report_document
 from utils.window_helpers import fetch_from_qdrant
 
 _LAST_REPORT_KEY = "furnacemind_last_report"
 
 
-def _remember_report(title: str, summary_text: str) -> None:
+def _remember_report(
+    title: str,
+    summary_text: str,
+    document: ReportDocument | None = None,
+) -> None:
     st.session_state[_LAST_REPORT_KEY] = {
         "title": title,
         "summary_text": summary_text,
+        "document": document,
     }
 
 
@@ -22,7 +29,11 @@ def _show_last_report() -> bool:
     if not report:
         return False
 
-    show_report(report["title"], report["summary_text"])
+    document = report.get("document") or document_from_markdown(
+        report["title"],
+        report["summary_text"],
+    )
+    show_report_document(document)
     return True
 
 
@@ -32,18 +43,18 @@ def _run_live_shift_report(
     *,
     include_analysis: bool,
     status_box,
-) -> str:
+) -> tuple[ReportDocument, str]:
     """Fetch live shift data and render markdown report text."""
     from agents.llm.llm_client import OpenRouterClient
     from reports.shift_report import ShiftReportService
 
     status_box.status("Fetching shift data...", expanded=False)
-    _, markdown = ShiftReportService(llm_client=OpenRouterClient()).generate(
+    _, document = ShiftReportService(llm_client=OpenRouterClient()).generate_document(
         shift_date,
         shift_label,
         include_analysis=include_analysis,
     )
-    return markdown
+    return document, document_to_markdown(document)
 
 
 def render_reports() -> None:
@@ -97,8 +108,9 @@ def render_reports() -> None:
         payload = fetch_from_qdrant(vector_store, window_id)
         if payload:
             title = f"Report ({window_id})"
-            _remember_report(title, payload["summary_text"])
-            show_report(title, payload["summary_text"])
+            document = document_from_markdown(title, payload["summary_text"])
+            _remember_report(title, payload["summary_text"], document)
+            show_report_document(document)
         else:
             st.warning(
                 f"No saved report found for {window_id}. "
@@ -115,8 +127,15 @@ def render_reports() -> None:
             f"{window_id} ({analysis_mode}). Re-submit to refresh."
         )
         title = f"Live Report ({window_id})"
-        _remember_report(title, st.session_state[cache_key])
-        show_report(title, st.session_state[cache_key])
+        cached = st.session_state[cache_key]
+        if isinstance(cached, dict):
+            document = cached["document"]
+            markdown = cached["summary_text"]
+        else:
+            markdown = cached
+            document = document_from_markdown(title, markdown)
+        _remember_report(title, markdown, document)
+        show_report_document(document)
         return
 
     status_box = st.empty()
@@ -124,7 +143,7 @@ def render_reports() -> None:
     spinner_message += " and LLM analysis..." if agentic_analysis else "..."
 
     with st.spinner(spinner_message):
-        report_text = _run_live_shift_report(
+        document, report_text = _run_live_shift_report(
             selected_date,
             shift_label,
             include_analysis=agentic_analysis,
@@ -132,7 +151,10 @@ def render_reports() -> None:
         )
 
     status_box.empty()
-    st.session_state[cache_key] = report_text
+    st.session_state[cache_key] = {
+        "document": document,
+        "summary_text": report_text,
+    }
     title = f"Live Report ({window_id})"
-    _remember_report(title, report_text)
-    show_report(title, report_text)
+    _remember_report(title, report_text, document)
+    show_report_document(document)


### PR DESCRIPTION
refactor(shift-reports): introduce structured report document architecture

- replace markdown-first flow with structured report models
- move business logic out of UI components
- add reusable rendering/document helpers
- extract material alias resolver service
- remove duplicated table rendering logic
- add cached materials fetching with logging
- improve renderer/service separation
- preserve legacy markdown compatibility
- add shift report and PNG rendering tests