### PR TITLE
Updated Ore material display to show contribution percentage against total burden.

### DIFF
--- a/src/reports/furnace_report/builder.py
+++ b/src/reports/furnace_report/builder.py
@@ -254,9 +254,26 @@ def _used_charge_materials(
             item = resolver.display_name(_material_candidates(charge_col))
             totals[item] = totals.get(item, 0.0) + mt
         if totals:
-            used[label] = "\n".join(
-                f"- {item} - {mt:.2f} mt" for item, mt in totals.items()
-            )
+            if key == "ore":
+                burden_total_mt = sum(
+                    float(value or 0.0)
+                    for value in (
+                        _charge_sum(charge_df, "sinter"),
+                        _charge_sum(charge_df, "ore"),
+                        _charge_sum(charge_df, "pellet"),
+                    )
+                )
+                used[label] = "\n".join(
+                    (
+                        f"- {item} - {mt:.2f} mt - "
+                        f"{mt / burden_total_mt * 100:.2f}% in burden"
+                    )
+                    for item, mt in totals.items()
+                )
+            else:
+                used[label] = "\n".join(
+                    f"- {item} - {mt:.2f} mt" for item, mt in totals.items()
+                )
 
     return used
 


### PR DESCRIPTION
## Summary

Updated Shift Report Ore section to display each Ore material's contribution as a percentage of total burden.

## Changes

* Added burden percentage calculation for Ore materials.
* Updated Ore section rendering to include percentage values.
* Ensured Ore material percentages sum up to the Ore burden ratio.


## Example

Before:

* Lloyds CLO - 141.12 mt
* Lloyds Metals Iron Fines Oversize (+10MM) - 144.27 mt

After:

* Lloyds CLO - 141.12 mt - 10.58% in burden
* Lloyds Metals Iron Fines Oversize (+10MM) - 10.82% in burden


## Proof

<img width="3840" height="2160" alt="live_report_2026-06-13_shift_a_tables (1)" src="https://github.com/user-attachments/assets/5773e019-927f-4085-932e-e725ef997232" />
Screenshot attached.
