### PR TITLE
added skin flows, tap open/closed tags and removed unecessary columns…

### DIFF
--- a/furnace_data/furnace_data/offline_tables.yml
+++ b/furnace_data/furnace_data/offline_tables.yml
@@ -311,14 +311,8 @@ tables:
       - property_3_name
       - property_4_name
       - material_name
-      - category_code
       - material_category
-      - material_description
-      - is_active
       - unit_code
-      - import_batch_id
-      - created_at
-      - updated_at
 
   plant_master.material_property_mapping:
     schema: plant_master

--- a/src/config/setting_ds_dv.yml
+++ b/src/config/setting_ds_dv.yml
@@ -345,6 +345,10 @@ data_tags:
     - "BF2_BFBD Furnace Body 9105mm Temp J"
     - "BF2_BFBD Furnace Body 9105mm Temp K"
     - "BF2_BFBD Furnace Body 9105mm Temp L"
+    - "BF02 Proper_SKIN FLOW TEMPERATURE_A"
+    - "BF02 Proper_SKIN FLOW TEMPERATURE_B"
+    - "BF02 Proper_SKIN FLOW TEMPERATURE_C"
+    - "BF02 Proper_SKIN FLOW TEMPERATURE_D"
 
 
   heatload_variables:
@@ -401,6 +405,9 @@ data_tags:
     - "BF2_PROC Top Temp 3"
     - "BF2_PROC Top Temp 4"
     - "BF2_PROC Top Temp Average"
+    - "BF2 BF Prop/Casting Open"
+    - "BF2 BF Prop/Casting Close"
+    - "BF2 Slag Start"
 
 data_mapping: # Using InfluxDB Measurement or Table names as keys
   temperature_profile:
@@ -514,6 +521,11 @@ data_mapping: # Using InfluxDB Measurement or Table names as keys
     BF2_BFBD Furnace Body 9105mm Temp J: temp_9105_j
     BF2_BFBD Furnace Body 9105mm Temp K: temp_9105_k
     BF2_BFBD Furnace Body 9105mm Temp L: temp_9105_l
+    BF02 Proper_SKIN FLOW TEMPERATURE_A: skin_flow_temp_a
+    BF02 Proper_SKIN FLOW TEMPERATURE_B: skin_flow_temp_b
+    BF02 Proper_SKIN FLOW TEMPERATURE_C: skin_flow_temp_c
+    BF02 Proper_SKIN FLOW TEMPERATURE_D: skin_flow_temp_d
+
 
 
   process_params:
@@ -560,6 +572,9 @@ data_mapping: # Using InfluxDB Measurement or Table names as keys
     TE_40532B Runner Temp CR side near to Taphole: runner_temp_cr_taphole
     TE_40532C Runner Temp PCI side near to skimmer: runner_temp_pci_skimmer
     TE_40532D Runner Temp CR side near to skimmer: runner_temp_cr_skimmer
+    BF2 BF Prop/Casting Open: tap_hole_open
+    BF2 BF Prop/Casting Close: tap_hole_close
+    BF2 Slag Start: slag_start
 
   heatload_delta_t:
     Heat load Row 6: heat_load_row_6  

--- a/src/reports/furnace_report/builder.py
+++ b/src/reports/furnace_report/builder.py
@@ -41,6 +41,9 @@ _ONLINE: dict[str, str] = {
     "nutcoke_rate": "Process Params - BF2_NUT COKE RATE PER THM",
     "pci_rate": "Process Params - BF2_COAL RATE PER THM",
     "runner_temp": "Process Params - TE_40532A Runner Temp PCI side near to Taphole",
+    "tap_hole_open": "Process Params - BF2 BF Prop/Casting Open",
+    "tap_hole_close": "Process Params - BF2 BF Prop/Casting Close",
+    "slag_start": "Process Params - BF2 Slag Start",
     # Differential pressure
     "furnace_top_dp": "Process Params - BF2_BODY_TOP DP",
     "furnace_bottom_dp": "Process Params - BF2_BODY_BOTTOM DP",
@@ -66,6 +69,10 @@ _ONLINE: dict[str, str] = {
     "bosh_q2": "Temperature Profile - BF2_BFBD Furnace Body 12975mm Temp B",
     "bosh_q3": "Temperature Profile - BF2_BFBD Furnace Body 12975mm Temp C",
     "bosh_q4": "Temperature Profile - BF2_BFBD Furnace Body 12975mm Temp D",
+    "skin_flow_temp_a": "Temperature Profile - BF02 Proper_SKIN FLOW TEMPERATURE_A",
+    "skin_flow_temp_b": "Temperature Profile - BF02 Proper_SKIN FLOW TEMPERATURE_B",
+    "skin_flow_temp_c": "Temperature Profile - BF02 Proper_SKIN FLOW TEMPERATURE_C",
+    "skin_flow_temp_d": "Temperature Profile - BF02 Proper_SKIN FLOW TEMPERATURE_D",
 }
 
 _HM: dict[str, str] = {
@@ -608,6 +615,7 @@ class ShiftBuilder(ReportBuilder[ShiftRawData, ShiftReportData]):
             etaco=_ps(df, "etaco"),
             raft=_ps(df, "raft"),
             uptake=_temp_row(df, "uptake_q1", "uptake_q2", "uptake_q3", "uptake_q4"),
+            skin_flow=_temp_row(df, "skin_flow_temp_a", "skin_flow_temp_b", "skin_flow_temp_c", "skin_flow_temp_d"),
             lower_stack=_temp_row(df, "ls_q1", "ls_q2", "ls_q3", "ls_q4"),
             belly=_temp_row(df, "belly_q1", "belly_q2", "belly_q3", "belly_q4"),
             bosh=_temp_row(df, "bosh_q1", "bosh_q2", "bosh_q3", "bosh_q4"),

--- a/src/reports/furnace_report/data.py
+++ b/src/reports/furnace_report/data.py
@@ -165,6 +165,7 @@ class ShiftReportData:
 
     # Temperatures
     uptake: TempRow
+    skin_flow: TempRow
     lower_stack: TempRow
     belly: TempRow
     bosh: TempRow

--- a/src/reports/furnace_report/renderer.py
+++ b/src/reports/furnace_report/renderer.py
@@ -99,7 +99,7 @@ def as_document(
             ["Parameter", "Q1", "Q2", "Q3", "Q4", "Std.Dev"],
             [
                 ["Uptake Temp (degC)", *_temp_cells(r.uptake)],
-                ["Skin flow", "-", "-", "-", "-", "-"],
+                ["Skin flow (degC)", *_temp_cells(r.skin_flow)],
                 ["Lower stack (degC)", *_temp_cells(r.lower_stack)],
                 ["Belly (degC)", *_temp_cells(r.belly)],
                 ["Bosh (degC)", *_temp_cells(r.bosh)],


### PR DESCRIPTION
## Changes

* Added Skin Flow Temperature field to Shift Reports.
* Updated data mapping and report generation logic.
* Added UI support for displaying temperature values.
* Included validation for missing or unavailable temperature data.
* Added Tap Open/Close tags. 
* Removed unnecessary columns in raw material strength analysis table.

## Testing

* Verified temperature values are displayed correctly.
* Tested report generation for current and historical shifts.
* Confirmed no impact on existing report functionality.
<img width="3840" height="2160" alt="live_report_2026-06-24_shift_b_tables" src="https://github.com/user-attachments/assets/2462031b-e7be-4890-80ef-d15d730e0e1d" />

