### PR TITLE
Implement FurnaceMind LangGraph Workflow and MRAG Document Storage

### DIFF
--- a/furnace_data/furnace_data/relational/models.py
+++ b/furnace_data/furnace_data/relational/models.py
@@ -8,12 +8,14 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     DateTime,
     Float,
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     String,
     Text,
     UniqueConstraint,
@@ -371,6 +373,14 @@ class MemoryDocument(Base):
     qdrant_collection: Mapped[str | None] = mapped_column(String(128), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     metadata_json: Mapped[dict | None] = mapped_column("metadata", JSON, nullable=True)
+    content_type: Mapped[str | None] = mapped_column(Text, nullable=True, deferred=True)
+    file_size: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, deferred=True
+    )
+    sha256: Mapped[str | None] = mapped_column(String(64), nullable=True, deferred=True)
+    file_bytes: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True, deferred=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/furnace_data/furnace_data/relational/repositories.py
+++ b/furnace_data/furnace_data/relational/repositories.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import date, datetime, time, timezone
 from types import SimpleNamespace
@@ -818,6 +819,143 @@ class MemoryDocumentRepository:
             session.expunge(document)
             return document
 
+    def store_document_file(
+        self,
+        *,
+        document_id: str,
+        user_id: str,
+        filename: str,
+        file_type: str | None,
+        content_type: str | None,
+        file_bytes: bytes,
+    ) -> None:
+        """Store the original uploaded document on its metadata row.
+
+        Args:
+             - document_id: str - SQL document row id from ``memory_documents``.
+             - user_id: str - Owner of the document; retained for interface clarity.
+             - filename: str - Original uploaded file name.
+             - file_type: str | None - File extension/type used by ingestion.
+             - content_type: str | None - Browser-provided MIME type when known.
+             - file_bytes: bytes - Exact uploaded file bytes.
+
+        Returns:
+             - return: None - The existing document row is updated in PostgreSQL.
+        """
+        if not document_id or not user_id or file_bytes is None:
+            return
+        payload = {
+            "document_id": str(document_id),
+            "filename": str(filename or "upload"),
+            "file_type": file_type,
+            "content_type": content_type,
+            "file_size": len(file_bytes),
+            "sha256": hashlib.sha256(file_bytes).hexdigest(),
+            "file_bytes": bytes(file_bytes),
+        }
+        with self._session_factory() as session:
+            session.execute(
+                update(MemoryDocument)
+                .where(MemoryDocument.document_id == payload["document_id"])
+                .values(
+                    filename=payload["filename"],
+                    file_type=payload["file_type"],
+                    content_type=payload["content_type"],
+                    file_size=payload["file_size"],
+                    sha256=payload["sha256"],
+                    file_bytes=payload["file_bytes"],
+                    updated_at=utc_now(),
+                )
+            )
+            session.commit()
+
+    def get_document_file(self, *, document_id: str) -> SimpleNamespace | None:
+        """Return original upload bytes stored on ``memory_documents``.
+
+        Args:
+             - document_id: str - SQL document row id.
+
+        Returns:
+             - return: SimpleNamespace | None - File metadata and bytes, or
+               ``None`` when the row/columns are unavailable.
+        """
+        if not document_id:
+            return None
+        try:
+            with self._session_factory() as session:
+                row = (
+                    session.execute(
+                        select(
+                            MemoryDocument.document_id,
+                            MemoryDocument.user_id,
+                            MemoryDocument.filename,
+                            MemoryDocument.file_type,
+                            MemoryDocument.content_type,
+                            MemoryDocument.file_size,
+                            MemoryDocument.sha256,
+                            MemoryDocument.file_bytes,
+                        ).where(MemoryDocument.document_id == str(document_id))
+                    )
+                    .mappings()
+                    .first()
+                )
+        except Exception:
+            return None
+        if row is None:
+            return None
+        values = dict(row)
+        raw_bytes = values.get("file_bytes")
+        if isinstance(raw_bytes, memoryview):
+            values["file_bytes"] = raw_bytes.tobytes()
+        elif raw_bytes is not None:
+            values["file_bytes"] = bytes(raw_bytes)
+        return SimpleNamespace(**values)
+
+    def get_document_file_by_mrag_id(
+        self,
+        *,
+        user_id: str | None,
+        mrag_document_id: str,
+    ) -> SimpleNamespace | None:
+        """Return stored upload bytes for the active SQL row backing an MRAG id.
+
+        Qdrant payloads carry the stable content-hash MRAG ``document_id``. The
+        SQL row has its own ``document_id`` primary key, so this method bridges
+        the two through ``memory_documents.metadata['document_id']`` before
+        loading bytes from the same row.
+        """
+        if not user_id or not mrag_document_id:
+            return None
+        for document in self.list_documents(user_id=user_id, active_only=True):
+            metadata = getattr(document, "metadata_json", None)
+            if not isinstance(metadata, dict):
+                continue
+            if str(metadata.get("document_id") or "") != str(mrag_document_id):
+                continue
+            return self.get_document_file(document_id=str(document.document_id))
+        return None
+
+    def delete_document_file(self, *, document_id: str) -> None:
+        """Clear original upload bytes from a deactivated document row."""
+        if not document_id:
+            return
+        try:
+            with self._session_factory() as session:
+                session.execute(
+                    update(MemoryDocument)
+                    .where(MemoryDocument.document_id == str(document_id))
+                    .values(
+                        content_type=None,
+                        file_size=None,
+                        sha256=None,
+                        file_bytes=None,
+                        updated_at=utc_now(),
+                    )
+                )
+                session.commit()
+        except Exception:
+            return
+
     def list_documents(
         self,
         *,
@@ -861,6 +999,7 @@ class MemoryDocumentRepository:
                 .values(is_active=False, updated_at=utc_now())
             )
             session.commit()
+        self.delete_document_file(document_id=document_id)
 
 
 class _ReflectedTableRepository:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dependencies = [
     "langchain-core==0.3.29 ; python_full_version >= '3.10' and python_full_version < '4.0'",
     "langchain-openai==0.2.14 ; python_full_version >= '3.10' and python_full_version < '4.0'",
     "langchain-text-splitters==0.3.4 ; python_full_version >= '3.10' and python_full_version < '4.0'",
+    "langgraph==0.2.69 ; python_full_version >= '3.10' and python_full_version < '4.0'",
     "langsmith==0.2.10 ; python_full_version >= '3.10' and python_full_version < '4.0'",
     "markdown-it-py==3.0.0 ; python_full_version >= '3.10' and python_full_version < '4.0'",
     "markupsafe==3.0.2 ; python_full_version >= '3.10' and python_full_version < '4.0'",

--- a/src/agents/furnace_tools.py
+++ b/src/agents/furnace_tools.py
@@ -61,12 +61,14 @@ _KNOWLEDGE_IMAGE_MAX_BYTES = 4_000_000
 _KNOWLEDGE_RERANK_CANDIDATES = 16
 _KNOWLEDGE_RETURN_LIMIT = 8
 
-# Absolute path: src/agents/furnace_tools.py -> parents[1] = src/ -> assets/data/
-# IST offset (tz-naive static ML dataset index matches this)
-_IST_OFFSET = timedelta(hours=5, minutes=30)
-
 
 def _ensure_dataset_store() -> Dict[str, Any]:
+    """Return the Streamlit session-state store for temporary datasets.
+
+    FurnaceMind tools pass data between model/tool calls by storing fetched or
+    merged DataFrames in ``st.session_state["fm_datasets"]``. This helper lazily
+    creates that dictionary and protects against stale non-dictionary values.
+    """
     if "fm_datasets" not in st.session_state or not isinstance(
         st.session_state.get("fm_datasets"), dict
     ):
@@ -75,6 +77,16 @@ def _ensure_dataset_store() -> Dict[str, Any]:
 
 
 def _new_dataset_id(prefix: str) -> str:
+    """Create a unique id for a dataset produced during the current session.
+
+    Args:
+        prefix: Short source label such as ``online``, ``offline``, ``merged``,
+            or ``static_shift``.
+
+    Returns:
+        Stable session-local id containing the prefix, UTC timestamp, and a
+        monotonically increasing Streamlit session counter.
+    """
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     counter = st.session_state.get("fm_dataset_counter", 0) + 1
     st.session_state["fm_dataset_counter"] = counter
@@ -82,6 +94,12 @@ def _new_dataset_id(prefix: str) -> str:
 
 
 def _to_ist_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize a DataFrame datetime index to Asia/Kolkata time.
+
+    Online and offline sources may return UTC-aware, UTC-naive, or already-local
+    timestamps. The UI and shift logic expect an IST index named ``time (IST)``.
+    Non-datetime and empty frames are returned unchanged.
+    """
     if df is None or df.empty:
         return df
     if not isinstance(df.index, pd.DatetimeIndex):
@@ -97,6 +115,17 @@ def _to_ist_index(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _parse_iso8601_utc(s: str) -> datetime:
+    """Parse a user/tool ISO timestamp into a UTC-aware ``datetime``.
+
+    Args:
+        s: ISO-8601 timestamp accepted by pandas, usually ending with ``Z``.
+
+    Returns:
+        Python ``datetime`` normalized to UTC.
+
+    Raises:
+        ValueError: If pandas cannot produce a timestamp for the input.
+    """
     dt = pd.to_datetime(s, utc=True)
     if isinstance(dt, pd.Timestamp):
         return dt.to_pydatetime()
@@ -104,6 +133,16 @@ def _parse_iso8601_utc(s: str) -> datetime:
 
 
 def _resolve_online_window(*, lookback: timedelta, window: Optional[str]) -> str:
+    """Choose the aggregation window for online telemetry fetches.
+
+    Args:
+        lookback: Resolved time span requested by the model/user.
+        window: Optional explicit aggregation window from the tool arguments.
+
+    Returns:
+        The explicit window when provided; otherwise ``1 hour`` for ranges above
+        one day and ``15 minutes`` for shorter ranges.
+    """
     if isinstance(window, str) and window.strip():
         return window.strip()
     # Policy from user:
@@ -113,6 +152,13 @@ def _resolve_online_window(*, lookback: timedelta, window: Optional[str]) -> str
 
 
 class OnlineFetchArgs(BaseModel):
+    """Validated arguments for fetching online Influx telemetry.
+
+    The model may request either a relative lookback window or exact UTC start
+    and end timestamps. Measurement groups are constrained to known online
+    telemetry groups so generated tool calls remain safe and predictable.
+    """
+
     lookback: Optional[str] = Field(
         default=None,
         description=(
@@ -150,10 +196,22 @@ class OnlineFetchArgs(BaseModel):
 
 
 class OfflineReportType(str):
-    """Canonical offline report types for tool-calling."""
+    """Canonical offline report type labels accepted by tool-calling.
+
+    The class is intentionally lightweight because the actual validation is
+    handled by ``OfflineFetchArgs.report_type``. Keeping these labels in one
+    place documents the offline data families exposed to the LLM.
+    """
 
 
 class OfflineFetchArgs(BaseModel):
+    """Validated arguments for loading offline report tables.
+
+    Offline data can be fetched by canonical report type, optional explicit
+    table name, time window, lookback period, and resampling cadence. The schema
+    keeps generated LLM tool calls inside the supported report families.
+    """
+
     report_type: Literal[
         "HM_SLAG",
         "CHARGE",
@@ -188,6 +246,12 @@ class OfflineFetchArgs(BaseModel):
 
 
 class MergeArgs(BaseModel):
+    """Validated arguments for merging online and offline datasets.
+
+    The merge tool aligns one online dataset with one or more offline datasets
+    so downstream analysis or plotting can operate on a single DataFrame.
+    """
+
     online_dataset_id: str = Field(
         description="Dataset id returned by fetch_online_data."
     )
@@ -200,6 +264,12 @@ class MergeArgs(BaseModel):
 
 
 class StaticShiftArgs(BaseModel):
+    """Validated arguments for loading one static 8-hour shift slice.
+
+    This schema is used when the model needs a known historical shift from the
+    pre-merged static dataset instead of live online/offline fetches.
+    """
+
     shift_date: str = Field(description="ISO date string YYYY-MM-DD")
     shift_label: Literal["A", "B", "C"] = Field(
         description="Shift: A (06:00-14:00), B (14:00-22:00), C (22:00-06:00 next day) IST"
@@ -207,6 +277,13 @@ class StaticShiftArgs(BaseModel):
 
 
 class MLDataArgs(BaseModel):
+    """Validated arguments for reading the static pre-merged ML dataset.
+
+    The static dataset is indexed in IST and can be sliced by time, optionally
+    resampled, and optionally reduced to columns matching user-provided keyword
+    filters.
+    """
+
     start_time: str = Field(
         description="Start of range. ISO-8601 or YYYY-MM-DD. Treated as IST (matches static dataset index). E.g. '2026-03-01' or '2026-03-01T06:00:00'."
     )
@@ -225,19 +302,78 @@ class MLDataArgs(BaseModel):
 
 
 class ConcatArgs(BaseModel):
+    """Validated arguments for vertically concatenating temporary datasets.
+
+    The concat tool lets the agent combine multiple compatible time slices into
+    one session DataFrame before plotting or comparing trends.
+    """
+
     dataset_ids: List[str] = Field(
         description="Dataset IDs to concatenate vertically (temporal union). Sorted by index; duplicate timestamps keep the last entry (prefer recent data)."
     )
 
 
+def _current_artifact_turn_id() -> str | None:
+    """Return the active chat-turn id used for artifact ownership.
+
+    The chat page sets ``fm_current_artifact_turn_id`` before one agent run.
+    Dataset and plot tools copy that id onto UI artifacts so the renderer can
+    show only charts/tables created by the current turn and hide stale outputs
+    from previous questions.
+
+    Returns:
+        Clean turn id from Streamlit session state, or ``None`` when no agent
+        turn is active.
+    """
+    value = st.session_state.get("fm_current_artifact_turn_id")
+    clean = str(value or "").strip()
+    return clean or None
+
+
+def _tag_artifact_turn(key: str) -> None:
+    """Attach current-turn ownership to a Streamlit artifact key.
+
+    Args:
+        key: Session-state key that stores the owner id for a UI artifact, such
+            as ``fm_df_turn_id`` or ``fm_fig_turn_id``.
+
+    Behavior:
+        If a turn id exists, the key is updated with that id. If no turn is
+        active, the key is removed so old artifacts are not treated as current.
+    """
+    turn_id = _current_artifact_turn_id()
+    if turn_id:
+        st.session_state[key] = turn_id
+    else:
+        st.session_state.pop(key, None)
+
+
 def _save_dataset(*, dataset_id: str, df: pd.DataFrame, meta: Dict[str, Any]) -> None:
+    """Persist a tool-produced DataFrame for later tools and UI rendering.
+
+    Args:
+        dataset_id: Session-local id returned to the model.
+        df: DataFrame produced by a fetch, merge, concat, or static-shift tool.
+        meta: Human-readable metadata describing source, time window, and shape.
+
+    Side effects:
+        Updates the dataset store, marks the active DataFrame for plotting, and
+        tags the DataFrame with the current chat turn id.
+    """
     store = _ensure_dataset_store()
     store[dataset_id] = {"df": df, "meta": meta}
     st.session_state.fm_df = df
     st.session_state.fm_df_meta = meta
+    _tag_artifact_turn("fm_df_turn_id")
 
 
 def _summarize_df(df: pd.DataFrame, *, dataset_id: str, title: str) -> str:
+    """Build a compact text summary returned after a dataset tool runs.
+
+    The summary gives the model enough context to decide whether it needs a
+    follow-up tool call, a plot, or a final natural-language answer without
+    sending the full dataset through the chat transcript.
+    """
     if df is None or df.empty:
         return f"{title}: No data found."
     preview = df.head(2).to_string() if len(df) else "<empty>"
@@ -250,12 +386,20 @@ def _summarize_df(df: pd.DataFrame, *, dataset_id: str, title: str) -> str:
 
 
 def _now_ist_naive() -> pd.Timestamp:
-    """Current time as IST tz-naive Timestamp (matches the static dataset index)."""
+    """Return current time as an IST tz-naive timestamp.
+
+    The static ML dataset uses tz-naive IST timestamps, so this helper avoids
+    mixing timezone-aware values with that index during range selection.
+    """
     return pd.Timestamp.utcnow().tz_localize(None) + pd.Timedelta(hours=5, minutes=30)
 
 
 def _parse_ist_naive(s: str) -> pd.Timestamp:
-    """Parse an ISO-8601 or YYYY-MM-DD string into a tz-naive IST Timestamp."""
+    """Parse a date/time string into the static dataset's IST-naive format.
+
+    Timezone-aware inputs are converted to Asia/Kolkata and then made naive so
+    they can be compared directly with the static ML dataset index.
+    """
     ts = pd.to_datetime(s)
     if ts.tzinfo is not None:
         ts = ts.tz_convert("Asia/Kolkata").tz_localize(None)
@@ -278,7 +422,11 @@ def _load_ml_dataset() -> tuple[pd.DataFrame, pd.Timestamp, pd.Timestamp]:
 
 
 def _ml_column_summary(df: pd.DataFrame) -> str:
-    """Return a compact grouped column summary for the ML dataset."""
+    """Return a compact grouped column summary for the ML dataset.
+
+    The text is included in tool responses when column discovery is useful, so
+    the model can choose relevant fields without receiving every row of data.
+    """
     groups: dict[str, list[str]] = {
         "KPIs": [],
         "Process params": [],
@@ -913,7 +1061,12 @@ def merge_furnace_data(
 
 
 def get_openai_tool_schemas() -> list[dict]:
-    """Return OpenAI/OpenRouter tool schemas for LLM function-calling."""
+    """Return OpenAI/OpenRouter tool schemas for FurnaceMind function-calling.
+
+    The schema list is the contract between the LLM and the local dispatcher.
+    Keep names, descriptions, required arguments, and enum values aligned with
+    the concrete tool functions below.
+    """
     return [
         {
             "type": "function",
@@ -1175,7 +1328,16 @@ def get_openai_tool_schemas() -> list[dict]:
 
 
 def execute_openai_tool_call(*, name: str, arguments: Dict[str, Any]) -> str:
-    """Dispatcher used by the OpenRouter tool-calling loop."""
+    """Dispatch one validated OpenAI/OpenRouter tool call to local code.
+
+    Args:
+        name: Function name selected by the model.
+        arguments: JSON-decoded arguments emitted by the model.
+
+    Returns:
+        String result from the matching tool, or a clear error string for
+        unknown tools and malformed plotting requests.
+    """
     if name == "fetch_ml_data":
         return fetch_ml_data(**arguments)
     if name == "concat_datasets":
@@ -1223,32 +1385,302 @@ def _knowledge_location(payload: dict[str, Any]) -> str:
     return ", ".join(bits)
 
 
-def _store_knowledge_image_results(results: list[dict[str, Any]]) -> None:
-    """Queue retrieved image chunks for the next multimodal LLM call.
+_VISUAL_KNOWLEDGE_MODALITIES = {"image", "page_image", "slide_image", "slide_render"}
+_IMAGE_FILE_TYPES = {"png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff"}
 
-    ``search_knowledge_docs`` returns text evidence through the tool-call
-    transcript, but image bytes cannot be embedded directly in that text result.
-    This helper stores the best visual hits in Streamlit session state so the
-    agent loop can later append them through
-    ``consume_pending_mrag_image_message()`` as ``image_url`` inputs.
+
+def _knowledge_payload_has_visual(payload: dict[str, Any]) -> bool:
+    """Return whether a retrieved knowledge payload can produce an image input.
+
+    The current MRAG flow stores original uploaded files in PostgreSQL and
+    stores chunk payloads in Qdrant. New payloads advertise visual evidence via
+    ``has_visual``, visual modalities, or image file types. Older chunks may
+    still carry ``image_path`` from the previous disk-backed implementation, so
+    that field remains supported during rollout.
+    """
+    modality = str(payload.get("modality") or "").strip().lower()
+    file_type = str(payload.get("file_type") or payload.get("type") or "").lower()
+    return bool(
+        payload.get("image_path")
+        or payload.get("has_visual")
+        or modality in _VISUAL_KNOWLEDGE_MODALITIES
+        or file_type in _IMAGE_FILE_TYPES
+    )
+
+
+def _stored_document_file_for_payload(payload: dict[str, Any]) -> Any | None:
+    """Load the PostgreSQL-stored original file for a Qdrant payload.
+
+    Qdrant payloads carry the stable MRAG ``document_id`` derived from the file
+    hash. The SQL table has its own primary key, so the repository bridges the
+    two ids through ``memory_documents.metadata`` and returns a row with
+    ``file_bytes`` loaded.
 
     Args:
-        results: Reranked Qdrant search results. Each result may include a
-            payload with an ``image_path`` pointing to a locally stored rendered
-            page, slide, or uploaded image.
+        payload: Qdrant payload for one retrieved knowledge chunk.
 
     Returns:
-        None. Updates or removes ``st.session_state["fm_mrag_image_results"]``.
+        Repository file record with original upload bytes, or ``None`` when the
+        repository/user/document mapping is unavailable.
+    """
+    repository = st.session_state.get("knowledge_document_repository")
+    if repository is None or not hasattr(repository, "get_document_file_by_mrag_id"):
+        return None
+    mrag_document_id = str(payload.get("document_id") or "").strip()
+    if not mrag_document_id:
+        return None
+    try:
+        return repository.get_document_file_by_mrag_id(
+            user_id=st.session_state.get("fm_user_id"),
+            mrag_document_id=mrag_document_id,
+        )
+    except Exception as exc:
+        st.session_state["fm_last_knowledge_visual_error"] = str(exc)
+        return None
+
+
+def _image_mime_type(
+    image_bytes: bytes,
+    *,
+    fallback_name: str = "visual.png",
+    fallback_type: str | None = None,
+) -> str:
+    """Infer a MIME type for image bytes sent to the vision model.
+
+    The resolver first trusts filename/type hints from the payload or SQL row.
+    If those are missing, it opens the bytes with PIL and falls back to PNG when
+    the format cannot be identified.
+    """
+    guessed = mimetypes.guess_type(fallback_name)[0]
+    if guessed:
+        return guessed
+    if fallback_type and fallback_type in _IMAGE_FILE_TYPES:
+        normalized = "jpeg" if fallback_type in {"jpg", "jpeg"} else fallback_type
+        return f"image/{normalized}"
+    try:
+        from PIL import Image
+
+        image = Image.open(io.BytesIO(image_bytes))
+        fmt = (image.format or "png").lower()
+        fmt = "jpeg" if fmt in {"jpg", "jpeg"} else fmt
+        return f"image/{fmt}"
+    except Exception:
+        return "image/png"
+
+
+def _render_pdf_page_visual(file_bytes: bytes, page_number: int | None) -> bytes | None:
+    """Render one PDF page from stored upload bytes for visual evidence.
+
+    This is used for ``page_image`` chunks after removing persistent rendered
+    page images from the codebase. The original PDF is read from PostgreSQL and
+    the requested page is rendered on demand.
+
+    Returns:
+        PNG bytes for the requested page, or ``None`` when rendering fails or
+        the page number is missing.
+    """
+    if page_number is None:
+        return None
+    try:
+        from agents.multimodal.parsers import extract_pdf_pages
+
+        for page in extract_pdf_pages(file_bytes, render_pages=True):
+            if int(page.get("page_number") or 0) == int(page_number):
+                image_bytes = page.get("image_bytes")
+                return bytes(image_bytes) if image_bytes else None
+    except Exception as exc:
+        st.session_state["fm_last_knowledge_visual_error"] = str(exc)
+    return None
+
+
+def _render_pptx_slide_visual(
+    file_bytes: bytes, slide_number: int | None
+) -> bytes | None:
+    """Render one PPTX slide from stored upload bytes for visual evidence.
+
+    The previous implementation could attach a saved slide image path. The new
+    implementation keeps the original PPTX in PostgreSQL and recreates the slide
+    image only when a retrieved ``slide_render`` chunk is needed by the model.
+
+    Returns:
+        PNG bytes for the requested slide, or ``None`` when rendering is not
+        available or the slide cannot be found.
+    """
+    if slide_number is None:
+        return None
+    try:
+        from agents.multimodal.parsers import render_pptx_slides
+
+        for slide in render_pptx_slides(file_bytes):
+            if int(slide.get("slide_number") or 0) == int(slide_number):
+                image_bytes = slide.get("image_bytes")
+                return bytes(image_bytes) if image_bytes else None
+    except Exception as exc:
+        st.session_state["fm_last_knowledge_visual_error"] = str(exc)
+    return None
+
+
+def _extract_pptx_embedded_visual(
+    file_bytes: bytes,
+    *,
+    slide_number: int | None,
+    image_index: int | None,
+) -> bytes | None:
+    """Extract one embedded PPTX image from stored upload bytes.
+
+    This resolves ``slide_image`` chunks. Instead of rendering the whole slide,
+    it opens the original PPTX stored in PostgreSQL and returns the specific
+    embedded image referenced by ``slide_number`` and ``slide_image_index``.
+    """
+    if slide_number is None:
+        return None
+    try:
+        from agents.multimodal.parsers import extract_pptx_slides
+
+        for slide in extract_pptx_slides(file_bytes):
+            if int(slide.get("slide_number") or 0) != int(slide_number):
+                continue
+            image_blobs = list(slide.get("image_blobs") or [])
+            if not image_blobs:
+                return None
+            index = int(image_index or 0)
+            if index < 0 or index >= len(image_blobs):
+                return None
+            return bytes(image_blobs[index])
+    except Exception as exc:
+        st.session_state["fm_last_knowledge_visual_error"] = str(exc)
+    return None
+
+
+def _visual_bytes_from_stored_document(
+    payload: dict[str, Any],
+    stored_document: Any,
+) -> tuple[bytes, str] | None:
+    """Reconstruct visual bytes for a retrieved MRAG chunk from PostgreSQL.
+
+    The resolver routes by payload modality: image uploads return original file
+    bytes, PDF page-image chunks render the requested page, PPTX slide-render
+    chunks render the requested slide, and PPTX slide-image chunks extract the
+    referenced embedded image.
+
+    Returns:
+        ``(image_bytes, mime_type)`` when the visual can be reconstructed, else
+        ``None``.
+    """
+    file_bytes = getattr(stored_document, "file_bytes", None)
+    if not file_bytes:
+        return None
+    file_bytes = bytes(file_bytes)
+    filename = str(
+        payload.get("source") or getattr(stored_document, "filename", "visual.png")
+    )
+    file_type = str(
+        payload.get("file_type")
+        or payload.get("type")
+        or getattr(stored_document, "file_type", "")
+    ).lower()
+    modality = str(payload.get("modality") or "").lower()
+
+    if modality == "image" or file_type in _IMAGE_FILE_TYPES:
+        return file_bytes, _image_mime_type(
+            file_bytes, fallback_name=filename, fallback_type=file_type
+        )
+    if modality == "page_image" and file_type == "pdf":
+        image_bytes = _render_pdf_page_visual(file_bytes, payload.get("page_number"))
+        return (image_bytes, "image/png") if image_bytes else None
+    if modality == "slide_render" and file_type == "pptx":
+        image_bytes = _render_pptx_slide_visual(file_bytes, payload.get("slide_number"))
+        return (image_bytes, "image/png") if image_bytes else None
+    if modality == "slide_image" and file_type == "pptx":
+        image_bytes = _extract_pptx_embedded_visual(
+            file_bytes,
+            slide_number=payload.get("slide_number"),
+            image_index=payload.get("slide_image_index"),
+        )
+        if image_bytes:
+            return image_bytes, _image_mime_type(
+                image_bytes,
+                fallback_name=filename,
+                fallback_type=str(payload.get("image_format") or ""),
+            )
+    return None
+
+
+def _visual_bytes_from_legacy_path(image_path: str) -> tuple[bytes, str] | None:
+    """Read visual evidence from old path-backed payloads.
+
+    This compatibility path supports chunks indexed before original files were
+    stored in PostgreSQL. New uploads should not rely on this path, but keeping
+    it avoids breaking older Qdrant payloads during rollout.
+    """
+    path = Path(str(image_path or ""))
+    if not path.exists() or not path.is_file():
+        return None
+    if path.stat().st_size > _KNOWLEDGE_IMAGE_MAX_BYTES:
+        return None
+    mime_type = mimetypes.guess_type(path.name)[0] or "image/png"
+    return path.read_bytes(), mime_type
+
+
+def _resolve_visual_attachment(
+    attachment: dict[str, Any],
+) -> tuple[bytes, str, str] | None:
+    """Resolve a queued MRAG visual attachment for model input.
+
+    The function supports both storage modes: legacy ``image_path`` payloads and
+    the new PostgreSQL-backed original-file flow. It also enforces the maximum
+    image size before the bytes are base64-encoded for the next multimodal LLM
+    call.
+
+    Returns:
+        ``(image_bytes, mime_type, source_label)`` when a usable visual exists,
+        otherwise ``None``.
+    """
+    payload = attachment.get("payload") or {}
+    label = str(attachment.get("label") or _knowledge_location(payload) or "visual")
+    image_path = str(payload.get("image_path") or attachment.get("image_path") or "")
+    if image_path:
+        legacy = _visual_bytes_from_legacy_path(image_path)
+        if legacy:
+            return legacy[0], legacy[1], label
+
+    stored_document = _stored_document_file_for_payload(payload)
+    if stored_document is None:
+        return None
+    resolved = _visual_bytes_from_stored_document(payload, stored_document)
+    if not resolved:
+        return None
+    image_bytes, mime_type = resolved
+    if len(image_bytes) > _KNOWLEDGE_IMAGE_MAX_BYTES:
+        return None
+    return image_bytes, mime_type, label
+
+
+def _store_knowledge_image_results(results: list[dict[str, Any]]) -> None:
+    """Queue retrieved visual chunks for the next multimodal LLM call.
+
+    Qdrant stores vector payloads, not image bytes. New MRAG payloads carry
+    enough location metadata to reconstruct visual evidence from the original
+    uploaded document stored in PostgreSQL. Older payloads with ``image_path``
+    are still supported during rollout.
+
+    Args:
+        results: Reranked knowledge-search results. Only payloads that can
+            provide visual evidence are retained, up to
+            ``_KNOWLEDGE_IMAGE_RESULT_LIMIT``.
+
+    Side effects:
+        Writes ``fm_mrag_image_results`` in Streamlit session state for
+        ``consume_pending_mrag_image_message`` to consume after the tool call.
     """
     attachments: list[dict[str, Any]] = []
     for result in results:
         payload = result.get("payload") or {}
-        image_path = str(payload.get("image_path") or "").strip()
-        if not image_path:
+        if not _knowledge_payload_has_visual(payload):
             continue
         attachments.append(
             {
-                "image_path": image_path,
+                "payload": payload,
                 "label": _knowledge_location(payload),
                 "score": result.get("score"),
             }
@@ -1390,7 +1822,9 @@ def _rerank_knowledge_results(
             vector_score = 0.0
         exact_bonus = 0.05 if query_text and query_text in searchable.lower() else 0.0
         modality_bonus = (
-            0.03 if payload.get("image_path") and "image" in query_tokens else 0.0
+            0.03
+            if _knowledge_payload_has_visual(payload) and "image" in query_tokens
+            else 0.0
         )
         rerank_score = (0.82 * float(vector_score)) + (0.18 * overlap)
         rerank_score += exact_bonus + modality_bonus
@@ -1464,10 +1898,11 @@ def _log_knowledge_retrieval_trace(
 def consume_pending_mrag_image_message() -> dict[str, Any] | None:
     """Build the visual-evidence message consumed after knowledge search.
 
-    ``search_knowledge_docs`` queues local image paths in session state. This
-    function removes that queue, reads usable image files, base64-encodes them,
-    and returns a model message compatible with OpenAI/OpenRouter multimodal
-    chat inputs. Missing files and oversized images are skipped.
+    ``search_knowledge_docs`` queues visual payload references in session state.
+    This function removes that queue, resolves each visual from the original
+    PostgreSQL-stored upload or a legacy local path, base64-encodes it, and
+    returns a model message compatible with OpenAI/OpenRouter multimodal chat
+    inputs. Missing files and oversized images are skipped.
 
     Returns:
         A user message containing source labels and ``image_url`` parts, or
@@ -1489,18 +1924,15 @@ def consume_pending_mrag_image_message() -> dict[str, Any] | None:
     ]
     attached_count = 0
     for attachment in attachments[:_KNOWLEDGE_IMAGE_RESULT_LIMIT]:
-        path = Path(str(attachment.get("image_path") or ""))
-        if not path.exists() or not path.is_file():
+        resolved = _resolve_visual_attachment(attachment)
+        if not resolved:
             continue
-        if path.stat().st_size > _KNOWLEDGE_IMAGE_MAX_BYTES:
-            continue
-
-        mime_type = mimetypes.guess_type(path.name)[0] or "image/png"
-        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        image_bytes, mime_type, label = resolved
+        encoded = base64.b64encode(image_bytes).decode("ascii")
         content.append(
             {
                 "type": "text",
-                "text": f"Visual source: {attachment.get('label') or path.name}",
+                "text": f"Visual source: {label}",
             }
         )
         content.append(
@@ -1517,7 +1949,13 @@ def consume_pending_mrag_image_message() -> dict[str, Any] | None:
 
 
 def _append_tool_error(*, tool_name: str, params: Dict[str, Any], error: str) -> None:
-    """Append tool failure details to tool_errors.md (best-effort, never raises)."""
+    """Append tool failure details to ``tool_errors.md`` without raising.
+
+    Tool execution errors should be visible to developers for later diagnosis,
+    but they must not crash the Streamlit chat session. This helper records the
+    tool name, sanitized parameters, timestamp, and error text on a best-effort
+    basis and silently returns if logging itself fails.
+    """
     try:
         _TOOL_ERRORS_PATH.parent.mkdir(parents=True, exist_ok=True)
         ts = datetime.now(timezone.utc).isoformat()
@@ -1749,6 +2187,7 @@ def execute_python_plot(code: str) -> str:
             # Save the figure object to session state for the UI to pick up
             st.session_state.fm_fig = local_vars["fig"]
             st.session_state.last_plot_code = code
+            _tag_artifact_turn("fm_fig_turn_id")
             return "Successfully generated Plotly figure."
         elif captured_output:
             # Diagnostic code (e.g. print(df.columns)) — return output so the LLM
@@ -1860,7 +2299,7 @@ def search_knowledge_docs(query: str) -> str:
         rerank_score = r.get("rerank_score")
         if isinstance(rerank_score, (int, float)):
             score_text = f"{score_text} | rerank={rerank_score:.3f}"
-        if payload.get("image_path"):
+        if _knowledge_payload_has_visual(payload):
             visual_note = (
                 "Visual attachment retrieved and provided to the model for inspection."
             )

--- a/src/agents/furnacemind/__init__.py
+++ b/src/agents/furnacemind/__init__.py
@@ -1,1 +1,6 @@
-"""FurnaceMind agent package."""
+"""FurnaceMind agent package.
+
+This package contains the Streamlit-facing FurnaceMind page helpers, prompt
+assembly, quick-skill support, and the LangGraph workflow that now drives the
+model/tool execution loop.
+"""

--- a/src/agents/furnacemind/agent.py
+++ b/src/agents/furnacemind/agent.py
@@ -1,135 +1,46 @@
-"""Agent loop — OpenRouter tool-calling with reasoning-model cleanup.
+"""FurnaceMind agent-loop entry point backed by LangGraph.
 
-``run_agent_loop`` drives the tool-calling conversation until the model
-produces a final text response (no tool_calls) or the iteration cap is hit.
-
-Reasoning models (e.g. MiniMax M2.5, DeepSeek-R1) emit ``<think>…</think>``
-blocks inside the content field.  ``_strip_thinking`` removes them so
-operators never see the internal reasoning trace.
+The public ``run_agent_loop`` function is intentionally kept stable for the
+Streamlit page. Internally, the model/tool loop is now executed by the
+LangGraph workflow in :mod:`agents.furnacemind.graph`.
 """
 
 from __future__ import annotations
 
-import json
-import re
+from typing import Any
 
-from agents.furnace_tools import (
-    consume_pending_mrag_image_message,
-    execute_openai_tool_call,
-)
+from agents.furnacemind.graph import run_furnacemind_graph_loop
 from agents.llm.llm_client import OpenRouterClient
-
-# ── Status labels shown in the UI while a tool is running ───────────────────
-_TOOL_LABELS: dict[str, str] = {
-    "fetch_ml_data": "Reading ML dataset…",
-    "concat_datasets": "Stitching datasets…",
-    "fetch_online_data": "Fetching live telemetry…",
-    "fetch_offline_data": "Fetching offline report…",
-    "merge_furnace_data": "Merging datasets…",
-    "load_static_shift_data": "Loading shift data…",
-    "search_shift_history": "Searching shift history…",
-    "search_knowledge_docs": "Searching knowledge docs…",
-    "execute_python_plot": "Generating plot…",
-}
-
-_MAX_ITERATIONS = 8
-
-
-def _strip_thinking(text: str) -> str:
-    """Remove ``<think>…</think>`` blocks emitted by reasoning models."""
-    return re.sub(
-        r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE
-    ).strip()
 
 
 def run_agent_loop(
     *,
     llm: OpenRouterClient,
-    messages: list[dict],
-    tools: list[dict],
-    status_box,
-    response_box,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    status_box: Any,
+    response_box: Any,
 ) -> str:
-    """Drive the tool-calling loop and return the final text response.
+    """Run the LangGraph workflow and render the final assistant response.
 
-    Parameters
-    ----------
-    llm:          Configured OpenRouterClient.
-    messages:     Full conversation history in OpenAI format (mutated in-place).
-    tools:        Tool schemas from ``get_openai_tool_schemas()``.
-    status_box:   ``st.empty()`` placeholder for status badges.
-    response_box: ``st.empty()`` placeholder for the streaming response text.
+    Args:
+        llm: Configured OpenRouter client used for chat completions.
+        messages: OpenAI-compatible conversation messages. The graph mutates
+            this list by appending assistant/tool turns so existing callers can
+            inspect the executed workflow.
+        tools: OpenAI-compatible tool schemas exposed to the model.
+        status_box: Streamlit placeholder used for tool progress updates.
+        response_box: Streamlit placeholder used to render the final response.
 
-    Returns
-    -------
-    str  Final assistant response (thinking blocks stripped).
+    Returns:
+        Final assistant response with reasoning ``<think>`` blocks removed.
     """
-    final_response = ""
-    last_tool_result: str | None = None
-
-    for _ in range(_MAX_ITERATIONS):
-        completion = llm.chat_completions(
-            messages=messages, tools=tools, tool_choice="auto"
-        )
-        msg = completion.choices[0].message
-
-        tool_calls = getattr(msg, "tool_calls", None)
-        content = _strip_thinking(getattr(msg, "content", None) or "")
-
-        if tool_calls:
-            # Append the assistant turn (with tool_calls) to the conversation.
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": content,
-                    "tool_calls": [
-                        {
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
-                        for tc in tool_calls
-                    ],
-                }
-            )
-
-            pending_visual_message: dict | None = None
-            for tc in tool_calls:
-                label = _TOOL_LABELS.get(
-                    tc.function.name, f"Running {tc.function.name}…"
-                )
-                status_box.status(label, expanded=False)
-                try:
-                    args = json.loads(tc.function.arguments or "{}")
-                except Exception:
-                    args = {}
-                result = execute_openai_tool_call(name=tc.function.name, arguments=args)
-                last_tool_result = result
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "name": tc.function.name,
-                        "content": result,
-                    }
-                )
-                if tc.function.name == "search_knowledge_docs":
-                    pending_visual_message = consume_pending_mrag_image_message()
-            if pending_visual_message is not None:
-                messages.append(pending_visual_message)
-            continue  # next iteration
-
-        # No tool_calls → this is the final text response.
-        final_response = content
-        break
-
+    final_response = run_furnacemind_graph_loop(
+        llm=llm,
+        messages=messages,
+        tools=tools,
+        status_box=status_box,
+    )
     status_box.empty()
-
-    if not final_response:
-        final_response = last_tool_result or "No response generated."
-
     response_box.markdown(final_response)
     return final_response

--- a/src/agents/furnacemind/ai_cooperate_page.py
+++ b/src/agents/furnacemind/ai_cooperate_page.py
@@ -1,4 +1,4 @@
-﻿"""Streamlit page renderer for the FurnaceMind AI Co-Operate experience.
+"""Streamlit page renderer for the FurnaceMind AI Co-Operate experience.
 
 This module wires together the FurnaceMind chat UI, PostgreSQL conversation
 persistence, rolling memory summaries, skill shortcuts, vector stores, and the
@@ -9,6 +9,7 @@ pieces live under ``ui.furnacemind`` and persistence logic lives under
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -624,8 +625,11 @@ def _reset_chat_session() -> None:
         "_fm_loaded_conversation_id",
         "pending_skill_prompt",
         "fm_fig",
+        "fm_fig_turn_id",
         "fm_df",
+        "fm_df_turn_id",
         "fm_df_meta",
+        "fm_current_artifact_turn_id",
     ):
         st.session_state.pop(key, None)
 
@@ -991,20 +995,28 @@ def render_ai_cooperate(*, field_labels: dict) -> None:  # noqa: ARG001
     if knowledge_visual_message is not None:
         messages.append(knowledge_visual_message)
     history_len_before = len(st.session_state.chat_history)
+    artifact_turn_id = uuid.uuid4().hex
+    st.session_state["fm_current_artifact_turn_id"] = artifact_turn_id
 
-    with st.chat_message("assistant"):
-        status_box = st.empty()
-        response_box = st.empty()
-        status_box.status("Thinking...", expanded=False)
-        final_response = run_agent_loop(
-            llm=llm,
-            messages=messages,
-            tools=tools,
-            status_box=status_box,
-            response_box=response_box,
-        )
+    try:
+        with st.chat_message("assistant"):
+            status_box = st.empty()
+            response_box = st.empty()
+            status_box.status("Thinking...", expanded=False)
+            final_response = run_agent_loop(
+                llm=llm,
+                messages=messages,
+                tools=tools,
+                status_box=status_box,
+                response_box=response_box,
+            )
+    finally:
+        st.session_state.pop("fm_current_artifact_turn_id", None)
 
-    chat_interface.inject_artifacts(history_len_before)
+    chat_interface.inject_artifacts(
+        history_len_before,
+        artifact_turn_id=artifact_turn_id,
+    )
 
     assistant_metadata = {"source": "furnacemind", **turn_message_metadata}
     assistant_message_id: str | None = None

--- a/src/agents/furnacemind/graph.py
+++ b/src/agents/furnacemind/graph.py
@@ -1,0 +1,445 @@
+"""LangGraph workflow for the FurnaceMind tool-calling agent.
+
+This module replaces the old hand-written model/tool loop with a small
+LangGraph state machine while keeping the rest of FurnaceMind unchanged. The
+Streamlit page still prepares the system prompt, selected skill context,
+semantically retrieved skill context, memory, feedback lessons, and knowledge
+context before this workflow starts.
+
+The graph is responsible for only the agent loop:
+
+1. Send the current message state and tool schemas to the LLM.
+2. If the LLM asks for tools, execute those tools through the existing
+   FurnaceMind tool dispatcher.
+3. Append tool outputs, optional MRAG visual messages, and assistant turns back
+   into the shared state.
+4. Continue until the model returns a final answer or the iteration limit is
+   reached.
+
+Tool failures are returned to the model as normal tool messages. That lets the
+assistant explain the problem or choose a fallback instead of letting a Streamlit
+page exception break the user session.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import lru_cache
+from typing import Any, TypedDict
+
+from langgraph.graph import END, StateGraph
+
+from agents.llm.llm_client import OpenRouterClient
+
+_MAX_ITERATIONS = 8
+
+_TOOL_LABELS: dict[str, str] = {
+    "fetch_ml_data": "Reading ML dataset...",
+    "concat_datasets": "Stitching datasets...",
+    "fetch_online_data": "Fetching live telemetry...",
+    "fetch_offline_data": "Fetching offline report...",
+    "merge_furnace_data": "Merging datasets...",
+    "load_static_shift_data": "Loading shift data...",
+    "search_shift_history": "Searching shift history...",
+    "search_knowledge_docs": "Searching knowledge docs...",
+    "execute_python_plot": "Generating plot...",
+}
+
+
+class FurnaceMindGraphState(TypedDict):
+    """State object passed between all FurnaceMind LangGraph nodes.
+
+    Fields:
+        llm: Configured OpenRouter client used for every model call.
+        messages: OpenAI-compatible conversation list. Nodes mutate this list by
+            appending assistant messages, tool outputs, and optional MRAG visual
+            messages.
+        tools: OpenAI-compatible tool schemas exposed to the model.
+        status_box: Streamlit placeholder used to show the currently running
+            tool label.
+        final_response: Final assistant response once the model stops requesting
+            tools.
+        last_tool_result: Last tool output, used as a defensive fallback if the
+            workflow reaches its iteration limit before a final response exists.
+        iterations: Number of tool-execution rounds already completed.
+    """
+
+    llm: OpenRouterClient
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]]
+    status_box: Any
+    final_response: str
+    last_tool_result: str | None
+    iterations: int
+
+
+def execute_openai_tool_call(*, name: str, arguments: dict[str, Any]) -> str:
+    """Run one FurnaceMind tool through the existing dispatcher.
+
+    Args:
+        name: OpenAI function/tool name selected by the model.
+        arguments: Parsed JSON arguments for that tool.
+
+    Returns:
+        String result produced by the existing FurnaceMind tool layer.
+
+    Notes:
+        The import is intentionally lazy. Importing ``agents.furnace_tools`` can
+        pull in optional plotting and data dependencies, so delaying it keeps this
+        graph module importable in lightweight tests and app startup paths.
+    """
+    from agents.furnace_tools import execute_openai_tool_call as _execute
+
+    return _execute(name=name, arguments=arguments)
+
+
+def consume_pending_mrag_image_message() -> dict[str, Any] | None:
+    """Read the visual MRAG message queued by knowledge-document search.
+
+    Returns:
+        A user-role OpenAI multimodal message containing image inputs, or
+        ``None`` when the latest knowledge search did not prepare visual context.
+
+    Notes:
+        ``search_knowledge_docs`` can retrieve both text chunks and image chunks.
+        The text comes back through the normal tool result. The image payload is
+        stored separately by the tool layer, then appended here so the next model
+        turn can reason over the retrieved visuals with a vision-capable model.
+    """
+    from agents.furnace_tools import consume_pending_mrag_image_message as _consume
+
+    return _consume()
+
+
+def _ensure_langchain_debug_compat() -> None:
+    """Provide the ``langchain.debug`` attribute expected by this dependency set.
+
+    LangGraph internally asks LangChain whether debug mode is enabled. The
+    versions currently locked for this application can expose that value through
+    a package shape that does not define ``langchain.debug``. Creating the
+    attribute before invocation keeps the graph stable without changing runtime
+    behavior. This shim can be removed after the LangChain and LangGraph package
+    versions are aligned.
+    """
+    try:
+        import langchain
+    except Exception:
+        return
+    if not hasattr(langchain, "debug"):
+        langchain.debug = False
+
+
+def _strip_thinking(text: str) -> str:
+    """Remove hidden reasoning blocks before storing or rendering output.
+
+    Args:
+        text: Raw assistant content returned by the chat model.
+
+    Returns:
+        Assistant content with any ``<think>...</think>`` block removed.
+    """
+    return re.sub(
+        r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE
+    ).strip()
+
+
+def _tool_call_attr(tool_call: Any, name: str, default: Any = None) -> Any:
+    """Read a tool-call field from SDK objects and dictionary test doubles.
+
+    Args:
+        tool_call: OpenAI SDK object, nested function object, or dictionary.
+        name: Attribute/key to read.
+        default: Value returned when the attribute/key is missing.
+
+    Returns:
+        The requested value from either object attributes or dictionary keys.
+    """
+    if isinstance(tool_call, dict):
+        return tool_call.get(name, default)
+    return getattr(tool_call, name, default)
+
+
+def _normalise_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    """Convert model tool-call objects into OpenAI-compatible dictionaries.
+
+    Args:
+        tool_calls: Tool calls returned by the LLM client. They may be SDK
+            objects in production or dictionaries in tests.
+
+    Returns:
+        A list of dictionaries with ``id``, ``type``, and ``function`` keys. The
+        normalized shape is what gets appended to ``messages`` before tool
+        outputs are added.
+    """
+    if not tool_calls:
+        return []
+
+    normalised: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        function = _tool_call_attr(tool_call, "function", {})
+        function_name = _tool_call_attr(function, "name", "")
+        function_args = _tool_call_attr(function, "arguments", "{}")
+        normalised.append(
+            {
+                "id": _tool_call_attr(tool_call, "id"),
+                "type": _tool_call_attr(tool_call, "type", "function"),
+                "function": {
+                    "name": function_name,
+                    "arguments": function_args,
+                },
+            }
+        )
+    return normalised
+
+
+def _parse_tool_arguments(raw_arguments: Any) -> dict[str, Any]:
+    """Parse LLM-emitted tool arguments into a dictionary safe for dispatch.
+
+    Args:
+        raw_arguments: JSON string, dictionary, empty value, or malformed value
+            emitted by the model for a tool call.
+
+    Returns:
+        Parsed dictionary arguments. Invalid JSON and non-dictionary JSON values
+        are treated as an empty argument dictionary so one malformed tool call
+        does not crash the workflow.
+    """
+    if isinstance(raw_arguments, dict):
+        return raw_arguments
+    if not isinstance(raw_arguments, str) or not raw_arguments.strip():
+        return {}
+    try:
+        parsed = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _tool_error_result(tool_name: str, exc: Exception) -> str:
+    """Format a tool exception as model-readable tool output.
+
+    Args:
+        tool_name: Tool name that failed. Empty names are replaced with a stable
+            placeholder for debugging.
+        exc: Exception raised by the tool dispatcher.
+
+    Returns:
+        A short string that can be appended as a normal ``role='tool'`` message.
+        The graph then loops back to the model, allowing a graceful final answer
+        instead of surfacing the exception in the Streamlit UI.
+    """
+    clean_name = tool_name or "unknown_tool"
+    return f"Tool `{clean_name}` failed: {type(exc).__name__}: {exc}"
+
+
+def _call_model(state: FurnaceMindGraphState) -> FurnaceMindGraphState:
+    """LangGraph node that asks the model for the next action.
+
+    Args:
+        state: Current workflow state containing messages, available tools, and
+            any prior tool outputs.
+
+    Returns:
+        The same state object after appending an assistant message. If the model
+        returned tool calls, they are normalized and stored on that assistant
+        message. If the model returned plain content, ``final_response`` is set
+        and the graph can finalize.
+    """
+    completion = state["llm"].chat_completions(
+        messages=state["messages"],
+        tools=state["tools"],
+        tool_choice="auto",
+    )
+    msg = completion.choices[0].message
+
+    content = _strip_thinking(getattr(msg, "content", None) or "")
+    tool_calls = _normalise_tool_calls(getattr(msg, "tool_calls", None))
+
+    assistant_message: dict[str, Any] = {
+        "role": "assistant",
+        "content": content,
+    }
+    if tool_calls:
+        assistant_message["tool_calls"] = tool_calls
+    else:
+        state["final_response"] = content
+
+    state["messages"].append(assistant_message)
+    return state
+
+
+def _execute_tools(state: FurnaceMindGraphState) -> FurnaceMindGraphState:
+    """LangGraph node that executes tool calls requested by the model.
+
+    Args:
+        state: Current workflow state whose latest assistant message contains
+            OpenAI-compatible ``tool_calls``.
+
+    Returns:
+        The same state object after appending one ``role='tool'`` message per
+        tool call, optional MRAG visual context, and an incremented iteration
+        count.
+
+    Error handling:
+        Tool exceptions are converted into tool-result messages. This keeps the
+        graph moving and gives the model a chance to explain the failure or use
+        another path instead of raising the exception to Streamlit.
+    """
+    assistant_message = state["messages"][-1]
+    pending_visual_message: dict[str, Any] | None = None
+
+    for tool_call in assistant_message.get("tool_calls", []):
+        function = tool_call.get("function", {})
+        tool_name = str(function.get("name") or "")
+        label = _TOOL_LABELS.get(tool_name, f"Running {tool_name}...")
+        state["status_box"].status(label, expanded=False)
+
+        try:
+            result = execute_openai_tool_call(
+                name=tool_name,
+                arguments=_parse_tool_arguments(function.get("arguments")),
+            )
+        except Exception as exc:
+            result = _tool_error_result(tool_name, exc)
+        state["last_tool_result"] = result
+        state["messages"].append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.get("id"),
+                "name": tool_name,
+                "content": result,
+            }
+        )
+        if tool_name == "search_knowledge_docs":
+            pending_visual_message = consume_pending_mrag_image_message()
+
+    if pending_visual_message is not None:
+        state["messages"].append(pending_visual_message)
+
+    state["iterations"] += 1
+    return state
+
+
+def _should_continue(state: FurnaceMindGraphState) -> str:
+    """Choose the next graph edge after a model response.
+
+    Args:
+        state: Current workflow state after ``call_model`` has appended the
+            latest assistant message.
+
+    Returns:
+        ``'execute_tools'`` when the assistant requested tool calls and the
+        iteration limit has not been reached; otherwise ``'finalize'``.
+    """
+    if state["iterations"] >= _MAX_ITERATIONS:
+        return "finalize"
+    latest_message = state["messages"][-1] if state["messages"] else {}
+    return "execute_tools" if latest_message.get("tool_calls") else "finalize"
+
+
+def _after_tools(state: FurnaceMindGraphState) -> str:
+    """Choose the next graph edge after tool execution.
+
+    Args:
+        state: Current workflow state after ``execute_tools`` has appended tool
+            results and incremented the iteration counter.
+
+    Returns:
+        ``'call_model'`` while another model turn is allowed; otherwise
+        ``'finalize'`` when the iteration cap has been reached.
+    """
+    return "finalize" if state["iterations"] >= _MAX_ITERATIONS else "call_model"
+
+
+def _finalize(state: FurnaceMindGraphState) -> FurnaceMindGraphState:
+    """LangGraph node that guarantees a user-visible final response.
+
+    Args:
+        state: Current workflow state after either a final model response or an
+            iteration-limit stop.
+
+    Returns:
+        The same state object with ``final_response`` populated. If the model did
+        not provide final text, the last tool result is used as a defensive
+        fallback; if no tool ran, a generic fallback message is used.
+    """
+    if not state.get("final_response"):
+        state["final_response"] = (
+            state.get("last_tool_result") or "No response generated."
+        )
+    return state
+
+
+@lru_cache(maxsize=1)
+def build_furnacemind_graph():
+    """Compile the FurnaceMind LangGraph workflow once per process.
+
+    Returns:
+        A compiled graph with three nodes:
+        ``call_model`` asks the LLM for the next action, ``execute_tools`` runs
+        requested tools, and ``finalize`` guarantees a response. Conditional
+        edges loop between model and tools until the model stops requesting
+        tools or the iteration cap is reached.
+    """
+    graph = StateGraph(FurnaceMindGraphState)
+    graph.add_node("call_model", _call_model)
+    graph.add_node("execute_tools", _execute_tools)
+    graph.add_node("finalize", _finalize)
+
+    graph.set_entry_point("call_model")
+    graph.add_conditional_edges(
+        "call_model",
+        _should_continue,
+        {
+            "execute_tools": "execute_tools",
+            "finalize": "finalize",
+        },
+    )
+    graph.add_conditional_edges(
+        "execute_tools",
+        _after_tools,
+        {
+            "call_model": "call_model",
+            "finalize": "finalize",
+        },
+    )
+    graph.add_edge("finalize", END)
+    return graph.compile()
+
+
+def run_furnacemind_graph_loop(
+    *,
+    llm: OpenRouterClient,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    status_box: Any,
+) -> str:
+    """Run one complete FurnaceMind model/tool workflow.
+
+    Args:
+        llm: Configured OpenRouter chat client used by the graph.
+        messages: OpenAI-compatible conversation state prepared by the page. The
+            list is mutated in-place with assistant turns, tool results, and any
+            MRAG visual messages produced during the run.
+        tools: OpenAI-compatible schemas for tools the model may call.
+        status_box: Streamlit placeholder used to display progress labels while
+            tools execute.
+
+    Returns:
+        Final assistant response text. Hidden reasoning blocks have already been
+        stripped before this value is set.
+    """
+    _ensure_langchain_debug_compat()
+    result = build_furnacemind_graph().invoke(
+        {
+            "llm": llm,
+            "messages": messages,
+            "tools": tools,
+            "status_box": status_box,
+            "final_response": "",
+            "last_tool_result": None,
+            "iterations": 0,
+        }
+    )
+    return result["final_response"]

--- a/src/agents/multimodal/ingestion.py
+++ b/src/agents/multimodal/ingestion.py
@@ -32,11 +32,9 @@ chunks when LibreOffice/``soffice`` is available on the host.
 from __future__ import annotations
 
 import hashlib
-import re
 import uuid
 from dataclasses import dataclass, field
 from io import BytesIO
-from pathlib import Path
 from typing import Any
 
 from PIL import Image
@@ -53,7 +51,6 @@ from agents.multimodal.parsers import (
 )
 from utils.logger import get_logger
 
-_IMAGE_DIR = Path("src/storage/furnacemind/mrag_images")
 _POINT_NAMESPACE = uuid.NAMESPACE_URL
 logger = get_logger(__name__)
 
@@ -63,10 +60,9 @@ class DocumentPart:
     """Normalized unit of knowledge that becomes one Qdrant point.
 
     ``DocumentPart`` is the common representation for every modality produced by
-    ingestion. Text-bearing parts keep extracted text in ``content`` and leave
-    ``image_path`` empty. Visual parts keep the original/rendered image on disk,
-    store that path in ``image_path``, and may include a short textual caption or
-    optional OCR text in ``content``.
+    ingestion. Text-bearing parts keep extracted text in ``content``. Visual
+    parts keep their bytes in memory long enough to create image embeddings, and
+    may include a short textual caption or optional OCR text in ``content``.
 
     Attributes:
         document_id: Stable content hash id shared by all parts from one upload.
@@ -78,8 +74,13 @@ class DocumentPart:
         chunk_index: Zero-based ordering across every part in the document.
         user_id: Optional owner id used for Qdrant filtering.
         content: Text/caption stored in payload and used for summaries.
-        image_path: Local path to the visual source. When present, the part is
-            embedded with ``embed_image``.
+        image_bytes: Visual bytes used to create multimodal embeddings. These
+            bytes are intentionally not written into the codebase; the original
+            uploaded document is stored in PostgreSQL and the visual bytes can be
+            reconstructed from that document when evidence needs to be attached.
+        image_path: Legacy local path to the visual source. Kept for backward
+            compatibility with older Qdrant payloads; new ingestion does not
+            populate it.
         page_number: Source PDF page number when applicable.
         slide_number: Source PPTX slide number when applicable.
         sheet_name: Source Excel sheet name when applicable.
@@ -94,6 +95,7 @@ class DocumentPart:
     chunk_index: int
     user_id: str | None = None
     content: str = ""
+    image_bytes: bytes | None = field(default=None, repr=False, compare=False)
     image_path: str | None = None
     page_number: int | None = None
     slide_number: int | None = None
@@ -122,8 +124,8 @@ class DocumentPart:
         The payload carries both retrieval metadata and answer-citation metadata.
         ``user_id`` and ``document_id`` support scoped search and deletion.
         ``source``, ``page_number``, ``slide_number``, and ``sheet_name`` let the
-        LLM cite exact locations. ``image_path`` lets the agent attach retrieved
-        visual evidence to a vision-capable model after vector search.
+        LLM cite exact locations. ``has_visual`` tells retrieval that the source
+        document can be reconstructed as visual evidence from PostgreSQL.
 
         Returns:
             Dictionary suitable for ``PointStruct.payload``.
@@ -139,6 +141,8 @@ class DocumentPart:
             "content": self.content,
             **self.metadata,
         }
+        if self.image_bytes is not None or self.image_path:
+            payload["has_visual"] = True
         if self.user_id:
             payload["user_id"] = self.user_id
         optional = {
@@ -178,18 +182,6 @@ def _read_upload_bytes(file) -> bytes:
     return data
 
 
-def _safe_name(name: str) -> str:
-    """Sanitize a value for use in generated local filenames.
-
-    Args:
-        name: Arbitrary filename/id fragment.
-
-    Returns:
-        ASCII-safe fragment containing letters, numbers, underscores, dots, and
-        hyphens. Returns ``"upload"`` if nothing usable remains.
-    """
-    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._")
-    return cleaned or "upload"
 
 
 def _document_id(file_bytes: bytes) -> str:
@@ -207,7 +199,7 @@ def _document_id(file_bytes: bytes) -> str:
 
 
 def _image_suffix(image_bytes: bytes, fallback: str = "png") -> str:
-    """Infer the best file extension for saved image bytes.
+    """Infer the best file extension for visual chunk bytes.
 
     Args:
         image_bytes: Raw image bytes.
@@ -223,31 +215,6 @@ def _image_suffix(image_bytes: bytes, fallback: str = "png") -> str:
         return "jpg" if fmt == "jpeg" else fmt
     except Exception:
         return fallback
-
-
-def _save_image_bytes(
-    *,
-    document_id: str,
-    chunk_id: str,
-    image_bytes: bytes,
-    suffix: str = "png",
-) -> str:
-    """Save visual chunk bytes under the MRAG image storage directory.
-
-    Args:
-        document_id: Stable upload id used in the generated filename.
-        chunk_id: Chunk id used in the generated filename.
-        image_bytes: Raw image bytes to write.
-        suffix: File extension without a leading dot.
-
-    Returns:
-        String path stored in Qdrant payload. Retrieval later reads this path and
-        sends the image to the multimodal LLM as visual evidence.
-    """
-    _IMAGE_DIR.mkdir(parents=True, exist_ok=True)
-    path = _IMAGE_DIR / f"{_safe_name(document_id)}_{_safe_name(chunk_id)}.{suffix}"
-    path.write_bytes(image_bytes)
-    return str(path)
 
 
 def _optional_ocr_text(image_bytes: bytes) -> str:
@@ -416,7 +383,7 @@ def _image_part(
     suffix: str = "png",
     metadata: dict[str, Any] | None = None,
 ) -> DocumentPart:
-    """Create an image-backed ``DocumentPart`` and save the visual bytes.
+    """Create an image-backed ``DocumentPart`` without writing local files.
 
     Args:
         document_id: Stable id shared by all parts from the upload.
@@ -430,21 +397,18 @@ def _image_part(
         user_id: Optional owner id for user-scoped retrieval.
         page_number: Source PDF page number, if any.
         slide_number: Source PPTX slide number, if any.
-        suffix: File extension for the saved image.
+        suffix: Original/rendered image extension stored as metadata for MIME
+            reconstruction. No file is written for this suffix.
         metadata: Optional parser-specific payload additions.
 
     Returns:
-        A ``DocumentPart`` with ``image_path`` populated. Because ``image_path``
-        is present, ``_embedding_for_part`` will embed it with ``embed_image``.
+        A ``DocumentPart`` with ``image_bytes`` populated. Because
+        ``image_bytes`` is present, ``_embedding_for_part`` will embed it with
+        ``embed_image``.
     """
     chunk_id = f"{modality}_{chunk_index:04d}"
-    image_path = _save_image_bytes(
-        document_id=document_id,
-        chunk_id=chunk_id,
-        image_bytes=image_bytes,
-        suffix=suffix,
-    )
     metadata_payload = {**(metadata or {})}
+    metadata_payload["image_format"] = suffix
     ocr_text = _optional_ocr_text(image_bytes)
     if ocr_text:
         metadata_payload["ocr_engine"] = "pytesseract"
@@ -459,7 +423,7 @@ def _image_part(
         chunk_index=chunk_index,
         user_id=user_id,
         content=content,
-        image_path=image_path,
+        image_bytes=image_bytes,
         page_number=page_number,
         slide_number=slide_number,
         metadata=metadata_payload,
@@ -610,7 +574,9 @@ def build_document_parts(
                     )
                 )
                 chunk_index += 1
-            for image_blob in slide.get("image_blobs") or []:
+            for slide_image_index, image_blob in enumerate(
+                slide.get("image_blobs") or []
+            ):
                 parts.append(
                     _image_part(
                         document_id=document_id,
@@ -626,6 +592,7 @@ def build_document_parts(
                             "Use this image for visual evidence from the presentation."
                         ),
                         suffix=_image_suffix(image_blob),
+                        metadata={"slide_image_index": slide_image_index},
                     )
                 )
                 chunk_index += 1
@@ -684,11 +651,20 @@ def _embedding_for_part(part: DocumentPart, embedding_client) -> list[float]:
         Dense vector for Qdrant.
 
     Behavior:
-        If ``part.image_path`` is set, the saved image bytes are read and passed
-        to ``embed_image(..., input_type="document")``. Otherwise ``part.content``
-        is passed to ``embed_text(..., input_type="document")``.
+        If ``part.image_bytes`` is set, those bytes are passed to
+        ``embed_image(..., input_type="document")``. Legacy ``image_path`` values
+        are still supported for old tests or payloads. Otherwise
+        ``part.content`` is passed to ``embed_text(..., input_type="document")``.
     """
+    if part.image_bytes is not None:
+        return _embed_image(
+            embedding_client,
+            part.image_bytes,
+            input_type="document",
+        )
     if part.image_path:
+        from pathlib import Path
+
         return _embed_image(
             embedding_client,
             Path(part.image_path).read_bytes(),
@@ -705,8 +681,9 @@ def _document_metadata(parts: list[DocumentPart]) -> dict[str, Any]:
 
     Returns:
         Metadata containing the stable document id, user id, chunk count,
-        modalities, file type, source page/slide/sheet lists, and saved image
-        paths. This supports the sidebar document library and delete cleanup.
+        modalities, file type, source page/slide/sheet lists, and visual chunk
+        count. This supports the sidebar document library and delete cleanup
+        without storing local filesystem paths.
     """
     return {
         "source": "furnacemind_knowledge",
@@ -722,9 +699,9 @@ def _document_metadata(parts: list[DocumentPart]) -> dict[str, Any]:
             {part.slide_number for part in parts if part.slide_number is not None}
         ),
         "sheets": sorted({part.sheet_name for part in parts if part.sheet_name}),
-        "image_paths": [
-            part.image_path for part in parts if part.image_path is not None
-        ],
+        "visual_chunk_count": len(
+            [part for part in parts if part.image_bytes is not None or part.image_path]
+        ),
     }
 
 
@@ -733,6 +710,8 @@ def _persist_document_metadata(
     document_repository: Any | None,
     user_id: str | None,
     filename: str,
+    file_bytes: bytes,
+    content_type: str | None,
     knowledge_store,
     parts: list[DocumentPart],
 ) -> Any | None:
@@ -740,10 +719,12 @@ def _persist_document_metadata(
 
     Args:
         document_repository: Repository with ``list_documents`` and
-            ``create_document`` methods, or ``None`` when SQL persistence is not
-            available.
+            ``create_document`` methods, and optionally ``store_document_file``;
+            or ``None`` when SQL persistence is not available.
         user_id: Current user id. Without this, no SQL document row is written.
         filename: Original uploaded filename.
+        file_bytes: Raw uploaded file bytes to store in PostgreSQL.
+        content_type: Browser-provided MIME type, when available.
         knowledge_store: Qdrant store providing ``collection_name``.
         parts: Parts successfully prepared for indexing.
 
@@ -756,6 +737,7 @@ def _persist_document_metadata(
 
     try:
         metadata = _document_metadata(parts)
+        document = None
         if hasattr(document_repository, "list_documents"):
             existing_documents = document_repository.list_documents(user_id=user_id)
             for document in existing_documents:
@@ -770,15 +752,33 @@ def _persist_document_metadata(
                     == knowledge_store.collection_name
                 )
                 if same_document and same_collection:
-                    return document
-        return document_repository.create_document(
-            user_id=user_id,
-            filename=filename,
-            file_type=parts[0].file_type,
-            qdrant_collection=knowledge_store.collection_name,
-            qdrant_point_ids=[part.point_id for part in parts],
-            metadata=metadata,
-        )
+                    break
+            else:
+                document = None
+        if document is None:
+            document = document_repository.create_document(
+                user_id=user_id,
+                filename=filename,
+                file_type=parts[0].file_type,
+                qdrant_collection=knowledge_store.collection_name,
+                qdrant_point_ids=[part.point_id for part in parts],
+                metadata=metadata,
+            )
+        if hasattr(document_repository, "store_document_file"):
+            try:
+                document_repository.store_document_file(
+                    document_id=getattr(document, "document_id"),
+                    user_id=user_id,
+                    filename=filename,
+                    file_type=parts[0].file_type,
+                    content_type=content_type,
+                    file_bytes=file_bytes,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "MRAG raw document save failed for %s: %s", filename, exc
+                )
+        return document
     except Exception as exc:
         logger.warning("MRAG document metadata save failed for %s: %s", filename, exc)
         return None
@@ -856,6 +856,7 @@ def process_file(
         metadata failures are caught and logged separately.
     """
     filename = getattr(file, "name", "upload")
+    content_type = getattr(file, "type", None)
     file_bytes = _read_upload_bytes(file)
     parts = build_document_parts(filename, file_bytes, user_id=user_id)
     if not parts:
@@ -889,6 +890,8 @@ def process_file(
         document_repository=document_repository,
         user_id=user_id,
         filename=filename,
+        file_bytes=file_bytes,
+        content_type=content_type,
         knowledge_store=knowledge_store,
         parts=parts,
     )

--- a/src/agents/tool_errors.md
+++ b/src/agents/tool_errors.md
@@ -1042,3 +1042,42 @@ name 'coke_df' is not defined
 ```
 '__import__'
 ```
+
+
+## 2026-07-01T12:06:55.694426+00:00
+**Tool:** execute_python_plot
+
+**Params:** `{"code": "import plotly.graph_objects as go\nfrom plotly.subplots import make_subplots\n\n# Define columns for plotting\nrows = ['heat_load_row_6', 'heat_load_row_7', 'heat_load_row_8', 'heat_load_row_9', 'heat_load_row_10']\nquads = ['heat_load_row6_10_q1', 'heat_load_row6_10_q2', 'heat_load_row6_10_q3', 'heat_load_row6_10_q4']\ntemps_18660 = ['temp_18660_a', 'temp_18660_b', 'temp_18660_c', 'temp_18660_d']\n\nfig = make_subplots(rows=3, cols=1, \n                    subplot_titles=(\"Row Heatloads (GJ)\", \"Quadrant Avg Heatloads (GJ)\", \"18660mm Temp Profile (°C)\"),\n                    vertical_spacing=0.1)\n\n# 1. Row Heatloads\nfor col in rows:\n    fig.add_trace(go.Scatter(x=df.index, y=df[col], name=col.replace('_', ' ').title()), row=1, col=1)\n\n# 2. Quadrant Heatloads\nfor col in quads:\n    fig.add_trace(go.Scatter(x=df.index, y=df[col], name=col.replace('_', ' ').title()), row=2, col=1)\n\n# 3. 18660mm Temps\nfor col in temps_18660:\n    fig.add_trace(go.Scatter(x=df.index, y=df[col], name=col.replace('_', ' ').title()), row=3, col=1)\n\nfig.update_layout(height=900, title_text=\"Recent Heatload & Temperature Behavior (8h)\", showlegend=True)\nfig.update_xaxes(title_text=\"Time\")\nfig.update_yaxes(title_text=\"Value\")\n"}`
+
+**Error:**
+
+```
+Disallowed token in code: \bimport\b
+```
+
+
+## 2026-07-02T12:34:35.960283+00:00
+**Tool:** fetch_online_data
+
+**Params:** `{"lookback": "8h", "window": null, "measurement_groups": ["<|\"|heatload_delta_t<|\"|"], "start_time_utc": null, "end_time_utc": null}`
+
+**Error:**
+
+```
+1 validation error for OnlineFetchArgs
+measurement_groups.0
+  Input should be 'process_params', 'cooling_water', 'heatload_delta_t', 'delta_t', 'temperature_profile' or 'miscellaneous' [type=literal_error, input_value='<|"|heatload_delta_t<|"|', input_type=str]
+    For further information visit https://errors.pydantic.dev/2.10/v/literal_error
+```
+
+
+## 2026-07-02T12:34:54.660843+00:00
+**Tool:** execute_python_plot
+
+**Params:** `{"code": "import plotly.graph_objects as go\nfrom plotly.subplots import make_subplots\n\n# Define columns for the plot\nrows = ['heat_load_row_6', 'heat_load_row_7', 'heat_load_row_8', 'heat_load_row_9', 'heat_load_row_10']\nquads = ['heat_load_row6_10_q1', 'heat_load_row6_10_q2', 'heat_load_row6_10_q3', 'heat_load_row6_10_q4']\n\nfig = make_subplots(rows=2, cols=1, \n                    subplot_titles=(\"Row-wise Heatloads\", \"Quadrant Average Heatloads (Rows 6-10)\"),\n                    vertical_spacing=0.15)\n\n# 1. Row Heatloads\nfor col in rows:\n    fig.add_trace(go.Scatter(x=df.index, y=df[col], name=col.replace('_', ' ').title()), row=1, col=1)\n\n# 2. Quadrant Heatloads\nfor col in quads:\n    fig.add_trace(go.Scatter(x=df.index, y=df[col], name=col.replace('_', ' ').title()), row=2, col=1)\n\nfig.update_layout(height=700, title_text=\"Heatload Behavior (Last 8 Hours)\", showlegend=True)\nfig.update_xaxes(title_text=\"Time\")\nfig.update_yaxes(title_text=\"Value\")\n"}`
+
+**Error:**
+
+```
+Disallowed token in code: \bimport\b
+```

--- a/src/ui/furnacemind/chat_interface.py
+++ b/src/ui/furnacemind/chat_interface.py
@@ -1,4 +1,4 @@
-﻿"""Streamlit chat UI helpers for FurnaceMind.
+"""Streamlit chat UI helpers for FurnaceMind.
 
 This module owns the chat-facing controls: rendering messages, capturing
 feedback, indexing/removing MRAG knowledge documents, and managing the
@@ -376,21 +376,44 @@ def render_feedback_controls(item: dict, *, raw_user_message: str) -> None:
     st.rerun()
 
 
-def inject_artifacts(history_len_before: int) -> None:
-    """
-    Append inline artifact messages for plot/dataframe produced this turn.
+def _artifact_belongs_to_turn(
+    *,
+    turn_key: str,
+    artifact_turn_id: str | None,
+) -> bool:
+    """Return True when an artifact should render for the current answer."""
+    if artifact_turn_id is None:
+        return True
+    return str(st.session_state.get(turn_key) or "") == artifact_turn_id
+
+
+def inject_artifacts(
+    history_len_before: int,
+    *,
+    artifact_turn_id: str | None = None,
+) -> None:
+    """Append plot/dataframe artifacts produced by the current agent turn.
 
     Args:
-         - history_len_before: int - Chat history length before agent execution.
+        history_len_before: Chat history length before agent execution. Used to
+            build stable artifact keys for the assistant turn.
+        artifact_turn_id: Agent-turn id created by the page before the model/tool
+            loop starts. When provided, only artifacts tagged with this same id
+            are rendered, preventing old charts or dataframes from being attached
+            to unrelated later answers.
 
     Returns:
-         - return: None - This function does not return a value.
+        None. Updates ``chat_history`` and ``fm_artifact_store`` in Streamlit
+        session state.
     """
     artifact_store: dict = st.session_state.setdefault("fm_artifact_store", {})
     history: list = st.session_state.chat_history
 
     new_figure = st.session_state.get("fm_fig")
-    if new_figure is not None:
+    if new_figure is not None and _artifact_belongs_to_turn(
+        turn_key="fm_fig_turn_id",
+        artifact_turn_id=artifact_turn_id,
+    ):
         key = f"fm_fig_{history_len_before}"
         if not any(item.get("artifact_key") == key for item in history):
             artifact_store[key] = new_figure
@@ -404,7 +427,14 @@ def inject_artifacts(history_len_before: int) -> None:
             )
 
     new_dataframe = st.session_state.get("fm_df")
-    if new_dataframe is not None and not new_dataframe.empty:
+    if (
+        new_dataframe is not None
+        and not new_dataframe.empty
+        and _artifact_belongs_to_turn(
+            turn_key="fm_df_turn_id",
+            artifact_turn_id=artifact_turn_id,
+        )
+    ):
         key = f"fm_df_{history_len_before}"
         if not any(item.get("artifact_key") == key for item in history):
             artifact_store[key] = new_dataframe

--- a/tests/test_chat_interface_skill_history.py
+++ b/tests/test_chat_interface_skill_history.py
@@ -1,5 +1,6 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
+import pandas as pd
 import streamlit as st
 
 from ui.furnacemind import chat_interface
@@ -48,4 +49,62 @@ def test_chat_history_to_messages_skips_inactive_skill_metadata() -> None:
         {"role": "user", "content": "normal question"},
         {"role": "assistant", "content": "normal answer"},
     ]
+    st.session_state.clear()
+
+
+def test_inject_artifacts_skips_stale_artifacts_from_previous_turn() -> None:
+    """A later text-only answer should not show old chart/table artifacts."""
+    st.session_state.clear()
+    st.session_state["chat_history"] = [
+        {"role": "user", "type": "text", "content": "summarize BMO"}
+    ]
+    st.session_state["fm_artifact_store"] = {}
+    st.session_state["fm_fig"] = object()
+    st.session_state["fm_fig_turn_id"] = "heatload_turn"
+    st.session_state["fm_df"] = pd.DataFrame({"heatload": [1.2]})
+    st.session_state["fm_df_turn_id"] = "heatload_turn"
+
+    chat_interface.inject_artifacts(1, artifact_turn_id="bmo_turn")
+
+    assert st.session_state["chat_history"] == [
+        {"role": "user", "type": "text", "content": "summarize BMO"}
+    ]
+    assert st.session_state["fm_artifact_store"] == {}
+    st.session_state.clear()
+
+
+def test_inject_artifacts_adds_artifacts_from_current_turn() -> None:
+    """New chart/table artifacts should render when tagged with this turn id."""
+    st.session_state.clear()
+    figure = object()
+    dataframe = pd.DataFrame({"eta_co": [42.1]})
+    st.session_state["chat_history"] = []
+    st.session_state["fm_artifact_store"] = {}
+    st.session_state["fm_fig"] = figure
+    st.session_state["fm_fig_turn_id"] = "eta_turn"
+    st.session_state["fm_df"] = dataframe
+    st.session_state["fm_df_turn_id"] = "eta_turn"
+    st.session_state["fm_df_meta"] = {"dataset_id": "eta_recent"}
+
+    chat_interface.inject_artifacts(0, artifact_turn_id="eta_turn")
+
+    assert st.session_state["chat_history"] == [
+        {
+            "role": "assistant",
+            "type": "plotly",
+            "artifact_key": "fm_fig_0",
+            "content": "",
+        },
+        {
+            "role": "assistant",
+            "type": "dataframe",
+            "artifact_key": "fm_df_0",
+            "content": "",
+            "meta": {"dataset_id": "eta_recent"},
+        },
+    ]
+    assert st.session_state["fm_artifact_store"] == {
+        "fm_fig_0": figure,
+        "fm_df_0": dataframe,
+    }
     st.session_state.clear()

--- a/tests/test_furnacemind_graph.py
+++ b/tests/test_furnacemind_graph.py
@@ -1,0 +1,198 @@
+"""Tests for the FurnaceMind LangGraph orchestration path."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents.furnacemind import graph as fm_graph
+
+
+class _StatusBox:
+    """Test double for the Streamlit status placeholder."""
+
+    def __init__(self) -> None:
+        self.labels: list[str] = []
+
+    def status(self, label: str, expanded: bool = False) -> None:  # noqa: ARG002
+        """Capture a status label emitted by the graph."""
+        self.labels.append(label)
+
+
+class _Function:
+    """Fake OpenAI SDK function-call object."""
+
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _ToolCall:
+    """Fake OpenAI SDK tool-call object."""
+
+    def __init__(self, name: str, arguments: str = "{}") -> None:
+        self.id = f"call_{name}"
+        self.function = _Function(name, arguments)
+
+
+class _Message:
+    """Fake OpenAI SDK chat message object."""
+
+    def __init__(self, *, content: str = "", tool_calls: Any = None) -> None:
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    """Fake OpenAI SDK choice wrapper."""
+
+    def __init__(self, message: _Message) -> None:
+        self.message = message
+
+
+class _Completion:
+    """Fake OpenAI SDK completion response."""
+
+    def __init__(self, message: _Message) -> None:
+        self.choices = [_Choice(message)]
+
+
+class _FakeLLM:
+    """Fake LLM that requests one tool before returning final text."""
+
+    def __init__(
+        self,
+        *,
+        tool_name: str = "fetch_ml_data",
+        tool_arguments: str = '{"start_time": "2026-01-01"}',
+        final_text: str = "<think>hidden</think>Final answer.",
+    ) -> None:
+        self.calls = 0
+        self.tool_name = tool_name
+        self.tool_arguments = tool_arguments
+        self.final_text = final_text
+
+    def chat_completions(  # noqa: ARG002
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        tool_choice: str = "auto",
+    ) -> _Completion:
+        """Return a fake tool call first, then final assistant text."""
+        self.calls += 1
+        if self.calls == 1:
+            return _Completion(
+                _Message(tool_calls=[_ToolCall(self.tool_name, self.tool_arguments)])
+            )
+        return _Completion(_Message(content=self.final_text))
+
+
+def test_furnacemind_graph_executes_tool_then_returns_final_response(monkeypatch):
+    """The graph should run requested tools and continue to final text."""
+    calls = []
+
+    def fake_execute_openai_tool_call(*, name: str, arguments: dict[str, Any]) -> str:
+        calls.append((name, arguments))
+        return "tool result"
+
+    monkeypatch.setattr(
+        fm_graph,
+        "execute_openai_tool_call",
+        fake_execute_openai_tool_call,
+    )
+
+    messages = [{"role": "user", "content": "check data"}]
+    status_box = _StatusBox()
+
+    response = fm_graph.run_furnacemind_graph_loop(
+        llm=_FakeLLM(),
+        messages=messages,
+        tools=[],
+        status_box=status_box,
+    )
+
+    assert response == "Final answer."
+    assert calls == [("fetch_ml_data", {"start_time": "2026-01-01"})]
+    assert status_box.labels == ["Reading ML dataset..."]
+    assert messages[-2] == {
+        "role": "tool",
+        "tool_call_id": "call_fetch_ml_data",
+        "name": "fetch_ml_data",
+        "content": "tool result",
+    }
+
+
+def test_furnacemind_graph_preserves_mrag_visual_message(monkeypatch):
+    """Knowledge-doc search should pass visual MRAG inputs to the next turn."""
+    visual_message = {
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}}
+        ],
+    }
+
+    monkeypatch.setattr(
+        fm_graph,
+        "execute_openai_tool_call",
+        lambda **_: "knowledge result",
+    )
+    monkeypatch.setattr(
+        fm_graph,
+        "consume_pending_mrag_image_message",
+        lambda: visual_message,
+    )
+
+    messages = [{"role": "user", "content": "inspect the chart"}]
+    response = fm_graph.run_furnacemind_graph_loop(
+        llm=_FakeLLM(
+            tool_name="search_knowledge_docs",
+            tool_arguments='{"query": "chart"}',
+            final_text="Chart answer.",
+        ),
+        messages=messages,
+        tools=[],
+        status_box=_StatusBox(),
+    )
+
+    assert response == "Chart answer."
+    assert visual_message in messages
+    assert messages.index(visual_message) > 0
+
+
+def test_furnacemind_graph_recovers_after_tool_error(monkeypatch):
+    """Tool failures should be returned to the model instead of crashing."""
+
+    def failing_tool(*, name: str, arguments: dict[str, Any]) -> str:  # noqa: ARG001
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(
+        fm_graph,
+        "execute_openai_tool_call",
+        failing_tool,
+    )
+
+    llm = _FakeLLM(
+        tool_name="fetch_online_data",
+        tool_arguments='{"measurement": "bf"}',
+        final_text="Telemetry is unavailable right now.",
+    )
+    messages = [{"role": "user", "content": "check live telemetry"}]
+
+    response = fm_graph.run_furnacemind_graph_loop(
+        llm=llm,
+        messages=messages,
+        tools=[],
+        status_box=_StatusBox(),
+    )
+
+    assert response == "Telemetry is unavailable right now."
+    assert llm.calls == 2
+    tool_messages = [message for message in messages if message.get("role") == "tool"]
+    assert tool_messages == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_fetch_online_data",
+            "name": "fetch_online_data",
+            "content": "Tool `fetch_online_data` failed: RuntimeError: database unavailable",
+        }
+    ]

--- a/tests/test_mrag_ingestion.py
+++ b/tests/test_mrag_ingestion.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import sys
 from io import BytesIO
-from pathlib import Path
 from types import SimpleNamespace
 
 os.environ.setdefault("OPENROUTER_API_KEY", "test-openrouter-key")
@@ -62,10 +61,14 @@ class FakeDocumentRepository:
 
     def __init__(self) -> None:
         self.create_calls: list[dict] = []
+        self.store_calls: list[dict] = []
 
     def create_document(self, **kwargs) -> object:
         self.create_calls.append(kwargs)
         return SimpleNamespace(document_id="doc-row-1")
+
+    def store_document_file(self, **kwargs) -> None:
+        self.store_calls.append(kwargs)
 
 
 class FakeChunkRepository:
@@ -118,6 +121,15 @@ def test_process_file_persists_qdrant_points_and_sql_metadata() -> None:
     assert create_call["metadata"]["user_id"] == "user-1"
     assert create_call["metadata"]["chunk_count"] == len(parts)
     assert create_call["metadata"]["modalities"] == ["text"]
+    assert create_call["metadata"]["visual_chunk_count"] == 0
+
+    assert len(repository.store_calls) == 1
+    store_call = repository.store_calls[0]
+    assert store_call["document_id"] == "doc-row-1"
+    assert store_call["user_id"] == "user-1"
+    assert store_call["filename"] == "operator_notes.txt"
+    assert store_call["file_type"] == "txt"
+    assert store_call["file_bytes"] == upload.getvalue()
 
     assert len(chunk_repository.create_calls) == 1
     chunk_call = chunk_repository.create_calls[0]
@@ -161,11 +173,15 @@ def test_process_file_embeds_uploaded_images_with_multimodal_client() -> None:
     )
     embedding = RecordingEmbedding()
 
+    repository = FakeDocumentRepository()
+    upload = NamedUpload(image_buffer.getvalue(), "stove_diagram.png")
+
     parts = process_file(
-        NamedUpload(image_buffer.getvalue(), "stove_diagram.png"),
+        upload,
         store,
         embedding,
         user_id="user-1",
+        document_repository=repository,
     )
 
     assert len(parts) == 1
@@ -177,8 +193,10 @@ def test_process_file_embeds_uploaded_images_with_multimodal_client() -> None:
     payload = point.payload
     assert point.vector == [0.7, 0.8, 0.9]
     assert payload["modality"] == "image"
-    assert payload["image_path"]
-    assert Path(payload["image_path"]).exists()
+    assert payload["has_visual"] is True
+    assert "image_path" not in payload
+    assert parts[0].image_bytes == upload.getvalue()
+    assert repository.store_calls[0]["file_bytes"] == upload.getvalue()
 
 
 def test_memory_document_reads_point_ids_from_metadata() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1066,6 +1066,7 @@ dependencies = [
     { name = "langchain-core", marker = "python_full_version < '4'" },
     { name = "langchain-openai", marker = "python_full_version < '4'" },
     { name = "langchain-text-splitters", marker = "python_full_version < '4'" },
+    { name = "langgraph", marker = "python_full_version < '4'" },
     { name = "langsmith", marker = "python_full_version < '4'" },
     { name = "markdown-it-py", marker = "python_full_version < '4'" },
     { name = "markupsafe", marker = "python_full_version < '4'" },
@@ -1294,6 +1295,7 @@ requires-dist = [
     { name = "langchain-core", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==0.3.29" },
     { name = "langchain-openai", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==0.2.14" },
     { name = "langchain-text-splitters", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==0.3.4" },
+    { name = "langgraph", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==0.2.69" },
     { name = "langsmith", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==0.2.10" },
     { name = "markdown-it-py", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==3.0.0" },
     { name = "markupsafe", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==3.0.2" },
@@ -2502,6 +2504,46 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph"
+version = "0.2.69"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core", marker = "python_full_version < '4'" },
+    { name = "langgraph-checkpoint", marker = "python_full_version < '4'" },
+    { name = "langgraph-sdk", marker = "python_full_version < '4'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/36/d75836c6c1b4a817bb22f591137dc533be02fdba171df4d80eac49e22043/langgraph-0.2.69.tar.gz", hash = "sha256:77bd6efd967b4f092ec31d2148b3e6ba3c31e202b4f3a975dbb082b19b5bb057", size = 128593, upload-time = "2025-01-31T01:12:18.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/be/f3489ee7a67bb5bb3dc256b9e95d19a44c31e337f0345a38b443018355e3/langgraph-0.2.69-py3-none-any.whl", hash = "sha256:b64a5755fa2c7f2f67608ff4ce0ef8c168b30a0fb551a6c1d2e19bf1d2268ce4", size = 148716, upload-time = "2025-01-31T01:12:16.703Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core", marker = "python_full_version < '4'" },
+    { name = "ormsgpack", marker = "python_full_version < '4'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/83/6404f6ed23a91d7bc63d7df902d144548434237d017820ceaa8d014035f2/langgraph_checkpoint-2.1.2.tar.gz", hash = "sha256:112e9d067a6eff8937caf198421b1ffba8d9207193f14ac6f89930c1260c06f9", size = 142420, upload-time = "2025-10-07T17:45:17.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f2/06bf5addf8ee664291e1b9ffa1f28fc9d97e59806dc7de5aea9844cbf335/langgraph_checkpoint-2.1.2-py3-none-any.whl", hash = "sha256:911ebffb069fd01775d4b5184c04aaafc2962fcdf50cf49d524cd4367c4d0c60", size = 45763, upload-time = "2025-10-07T17:45:16.19Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.1.74"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "python_full_version < '4'" },
+    { name = "orjson", marker = "python_full_version < '4'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/f7/3807b72988f7eef5e0eb41e7e695eca50f3ed31f7cab5602db3b651c85ff/langgraph_sdk-0.1.74.tar.gz", hash = "sha256:7450e0db5b226cc2e5328ca22c5968725873630ef47c4206a30707cb25dc3ad6", size = 72190, upload-time = "2025-07-21T16:36:50.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/1a/3eacc4df8127781ee4b0b1e5cad7dbaf12510f58c42cbcb9d1e2dba2a164/langgraph_sdk-0.1.74-py3-none-any.whl", hash = "sha256:3a265c3757fe0048adad4391d10486db63ef7aa5a2cbd22da22d4503554cb890", size = 50254, upload-time = "2025-07-21T16:36:49.134Z" },
+]
+
+[[package]]
 name = "langsmith"
 version = "0.2.10"
 source = { registry = "https://pypi.org/simple" }
@@ -3424,6 +3466,62 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/02/6b2103898d60c2565bf97abffdf3a4cf338920b9feb55eec1fd791ab10ee/orjson-3.10.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d9c3a87abe6f849a4a7ac8a8a1dede6320a4303d5304006b90da7a3cd2b70d2c", size = 130825, upload-time = "2024-12-29T23:42:03.432Z" },
     { url = "https://files.pythonhosted.org/packages/87/7c/db115e2380435da569732999d5c4c9b9868efe72e063493cb73c36bb649a/orjson-3.10.13-cp313-cp313-win32.whl", hash = "sha256:527afb6ddb0fa3fe02f5d9fba4920d9d95da58917826a9be93e0242da8abe94a", size = 143723, upload-time = "2024-12-29T23:42:05.645Z" },
     { url = "https://files.pythonhosted.org/packages/cc/5e/c2b74a0b38ec561a322d8946663924556c1f967df2eefe1b9e0b98a33950/orjson-3.10.13-cp313-cp313-win_amd64.whl", hash = "sha256:b5f7c298d4b935b222f52d6c7f2ba5eafb59d690d9a3840b7b5c5cda97f6ec5c", size = 134968, upload-time = "2024-12-29T23:42:08.104Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/fa/a91f70829ebccf6387c4946e0a1a109f6ba0d6a28d65f628bedfad94b890/ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657", size = 378262, upload-time = "2026-01-18T20:55:22.284Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/62/3698a9a0c487252b5c6a91926e5654e79e665708ea61f67a8bdeceb022bf/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13034dc6c84a6280c6c33db7ac420253852ea233fc3ee27c8875f8dd651163", size = 203034, upload-time = "2026-01-18T20:55:53.324Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3a/f716f64edc4aec2744e817660b317e2f9bb8de372338a95a96198efa1ac1/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59f5da97000c12bc2d50e988bdc8576b21f6ab4e608489879d35b2c07a8ab51a", size = 210538, upload-time = "2026-01-18T20:55:20.097Z" },
+    { url = "https://files.pythonhosted.org/packages/72/30/a436be9ce27d693d4e19fa94900028067133779f09fc45776db3f689c822/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e4459c3f27066beadb2b81ea48a076a417aafffff7df1d3c11c519190ed44f2", size = 212401, upload-time = "2026-01-18T20:55:46.447Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c5/cde98300fd33fee84ca71de4751b19aeeca675f0cf3c0ec4b043f40f3b76/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a1c460655d7288407ffa09065e322a7231997c0d62ce914bf3a96ad2dc6dedd", size = 387080, upload-time = "2026-01-18T20:56:00.884Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/31/30bf445ef827546747c10889dd254b3d84f92b591300efe4979d792f4c41/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:458e4568be13d311ef7d8877275e7ccbe06c0e01b39baaac874caaa0f46d826c", size = 482346, upload-time = "2026-01-18T20:55:39.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f5/e1745ddf4fa246c921b5ca253636c4c700ff768d78032f79171289159f6e/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8cde5eaa6c6cbc8622db71e4a23de56828e3d876aeb6460ffbcb5b8aff91093b", size = 425178, upload-time = "2026-01-18T20:55:27.106Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a2/e6532ed7716aed03dede8df2d0d0d4150710c2122647d94b474147ccd891/ormsgpack-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:dc7a33be14c347893edbb1ceda89afbf14c467d593a5ee92c11de4f1666b4d4f", size = 117183, upload-time = "2026-01-18T20:55:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

This PR improves FurnaceMind’s agent workflow and multimodal knowledge handling.


# Problem Solved

Previously, FurnaceMind had three main issues:

- Uploaded knowledge documents were partially handled through local/generated files instead of keeping the original document in database storage.
- Document-based questions could incorrectly trigger furnace dataset/plot tools.
- Tool failures could bubble up and crash the app instead of returning a graceful assistant response.

# What Changed

- Added a LangGraph-based FurnaceMind workflow with state handling.
- Wrapped existing FurnaceMind tools so they can run inside the graph.
- Added safe tool error handling so failed tools return tool messages instead of crashing the app.
- Updated tool routing so document questions use MRAG/knowledge retrieval, while furnace data questions use dataset/plot tools.
- Updated MRAG ingestion to store the original uploaded document in Postgres.
- Kept document chunks and embeddings in Qdrant.
- Removed reliance on storing rendered document images in the codebase.
- Added file metadata support for uploaded documents: content type, file size, SHA-256 hash, and file bytes.
- Improved FurnaceMind tool docstrings for maintainability.
- Added/updated tests for LangGraph workflow, MRAG ingestion, and chat history behavior.


# Changed Code Files

- `furnace_data/furnace_data/relational/models.py`
- `furnace_data/furnace_data/relational/repositories.py`
- `pyproject.toml`
- `src/agents/furnace_tools.py`
- `src/agents/furnacemind/__init__.py`
- `src/agents/furnacemind/agent.py`
- `src/agents/furnacemind/ai_cooperate_page.py`
- `src/agents/furnacemind/graph.py`
- `src/agents/multimodal/ingestion.py`
- `src/agents/tool_errors.md`
- `src/ui/furnacemind/chat_interface.py`
- `tests/test_chat_interface_skill_history.py`
- `tests/test_furnacemind_graph.py`
- `tests/test_mrag_ingestion.py`
- `uv.lock`