### PR TITLE
Add FurnaceMind web search and knowledge ingestion

### DIFF
--- a/furnace_data/furnace_data/relational/repositories.py
+++ b/furnace_data/furnace_data/relational/repositories.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 import pandas as pd
 from sqlalchemy import MetaData, Table, delete, func, select, update
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session, sessionmaker, undefer
 
 from .models import (
     BURDEN_VALUE_COLUMNS,
@@ -979,7 +979,11 @@ class MemoryDocumentRepository:
              - return: Uploaded document rows detached from the session.
         """
         with self._session_factory() as session:
-            stmt = select(MemoryDocument)
+            stmt = select(MemoryDocument).options(
+                undefer(MemoryDocument.content_type),
+                undefer(MemoryDocument.file_size),
+                undefer(MemoryDocument.sha256),
+            )
             if user_id:
                 stmt = stmt.where(MemoryDocument.user_id == user_id)
             if active_only:

--- a/furnace_data/furnace_data/relational/repositories.py
+++ b/furnace_data/furnace_data/relational/repositories.py
@@ -979,6 +979,9 @@ class MemoryDocumentRepository:
              - return: Uploaded document rows detached from the session.
         """
         with self._session_factory() as session:
+            # These small columns are deferred on the model, but callers inspect
+            # them after the rows are detached below. Load them while the session
+            # is active to avoid a detached-instance lazy-load error.
             stmt = select(MemoryDocument).options(
                 undefer(MemoryDocument.content_type),
                 undefer(MemoryDocument.file_size),

--- a/src/agents/furnace_tools.py
+++ b/src/agents/furnace_tools.py
@@ -19,6 +19,7 @@ Exposes twelve tool functions dispatched by :func:`execute_openai_tool_call`:
 import base64
 import io
 import json
+import logging
 import mimetypes
 import re
 from datetime import datetime, timedelta, timezone
@@ -52,6 +53,8 @@ from furnace_data.offline import (
 from utils.settings import settings
 from utils.shift_windows import shift_window_naive
 
+logger = logging.getLogger(__name__)
+
 # CONFIG
 config = load_config("setting_ds_dv.yml")
 
@@ -65,6 +68,7 @@ _KNOWLEDGE_IMAGE_RESULT_LIMIT = 3
 _KNOWLEDGE_IMAGE_MAX_BYTES = 4_000_000
 _KNOWLEDGE_RERANK_CANDIDATES = 16
 _KNOWLEDGE_RETURN_LIMIT = 8
+_WEB_SEARCH_SESSION_COUNT_KEY = "fm_web_search_request_count"
 
 
 def _ensure_dataset_store() -> Dict[str, Any]:
@@ -556,6 +560,63 @@ def _is_web_search_enabled() -> bool:
     return bool(st.session_state.get("fm_web_search_enabled", False))
 
 
+def web_search_session_usage() -> tuple[int, int]:
+    """Return logical web-search requests used and allowed in this session.
+
+    The counter is stored in Streamlit session state, so reruns preserve it but
+    a new browser session starts with a fresh allowance. Provider-level retries
+    remain an implementation detail and do not consume additional logical
+    interactions from this user-facing limit.
+    """
+    configured_limit = getattr(
+        settings.web_search,
+        "max_requests_per_session",
+        5,
+    )
+    try:
+        limit = max(1, int(configured_limit))
+    except (TypeError, ValueError):
+        limit = 5
+    try:
+        used = max(0, int(st.session_state.get(_WEB_SEARCH_SESSION_COUNT_KEY, 0)))
+    except (TypeError, ValueError):
+        used = 0
+    return used, limit
+
+
+def _reserve_web_search_request() -> tuple[bool, int, int]:
+    """Reserve one session search before making an external provider request."""
+    used, limit = web_search_session_usage()
+    if used >= limit:
+        logger.warning(
+            "web_search_session_limit_reached",
+            extra={
+                "provider": settings.web_search.provider,
+                "requests_used": used,
+                "request_limit": limit,
+            },
+        )
+        return False, used, limit
+    used += 1
+    st.session_state[_WEB_SEARCH_SESSION_COUNT_KEY] = used
+    return True, used, limit
+
+
+def _web_search_limit_message(*, used: int, limit: int) -> str:
+    """Render a structured tool response when the session quota is exhausted."""
+    return "\n".join(
+        [
+            "WEB_SEARCH_RESULTS",
+            f"Provider: {settings.web_search.provider}",
+            "Status: session_limit_reached",
+            f"Session requests used: {used}/{limit}",
+            "Missing-data notes:",
+            "- This browser session has reached its configured web-search limit.",
+            "- Continue with internal sources or start a new browser session.",
+        ]
+    )
+
+
 def web_search(*, query: str, limit: int | None = None) -> str:
     """Search the public web for current or external reference information.
 
@@ -577,6 +638,9 @@ def web_search(*, query: str, limit: int | None = None) -> str:
                 "Turn on Web search in the FurnaceMind sidebar to fetch "
                 "current external sources."
             )
+        allowed, used, session_limit = _reserve_web_search_request()
+        if not allowed:
+            return _web_search_limit_message(used=used, limit=session_limit)
         return search_web(args.query, limit=args.limit)
     except ValidationError as exc:
         _append_tool_error(tool_name="web_search", params=params, error=str(exc))

--- a/src/agents/furnace_tools.py
+++ b/src/agents/furnace_tools.py
@@ -1,18 +1,19 @@
 """Tool functions for the FurnaceMind AI Co-Operate agent.
 
-Exposes ten tool functions dispatched by
-:func:`execute_openai_tool_call`:
+Exposes twelve tool functions dispatched by :func:`execute_openai_tool_call`:
 
-1. ``fetch_online_data`` — fetch InfluxDB telemetry for any measurement group.
-2. ``fetch_offline_data`` — fetch shift/daily report data from the offline database.
-3. ``merge_furnace_data`` — align and merge online + offline datasets on timestamps.
-4. ``fetch_ml_data`` — load a date-range slice from the static pre-merged ML dataset.
-5. ``concat_datasets`` — concatenate multiple datasets vertically (temporal union).
-6. ``load_static_shift_data`` — load 8-hour shift data from the static ML dataset.
-7. ``search_shift_history`` — semantic vector search over Qdrant shift summaries.
-8. ``search_knowledge_docs`` — semantic search over uploaded operator documents.
-9. ``render_heatload_plot`` — deterministic plot for recent heatload telemetry.
-10. ``execute_python_plot`` — sandboxed execution of agent-generated Plotly code.
+1. ``fetch_online_data`` - fetch InfluxDB telemetry for any measurement group.
+2. ``fetch_offline_data`` - fetch shift/daily report data from the offline database.
+3. ``merge_furnace_data`` - align and merge online + offline datasets on timestamps.
+4. ``fetch_ml_data`` - load a date-range slice from the static pre-merged ML dataset.
+5. ``concat_datasets`` - concatenate multiple datasets vertically.
+6. ``load_static_shift_data`` - load 8-hour shift data from the static ML dataset.
+7. ``search_shift_history`` - semantic vector search over shift summaries.
+8. ``search_knowledge_docs`` - semantic search over uploaded operator documents.
+9. ``web_search`` - external web search for current/public information.
+10. ``web_scrape_ingest`` - scrape an approved URL into shared MRAG knowledge.
+11. ``render_heatload_plot`` - deterministic plot for recent heatload telemetry.
+12. ``execute_python_plot`` - sandboxed execution of agent-generated Plotly code.
 """
 
 import base64
@@ -31,6 +32,8 @@ import streamlit as st
 from langchain.tools import tool
 from pydantic import BaseModel, Field, ValidationError
 
+from agents.furnacemind.web_ingestion import ingest_external_knowledge_url
+from agents.furnacemind.web_search import search_web
 from config.config_loader import load_config
 from data.fetch_presets import (
     OFFLINE_REPORT_LABEL_MAP,
@@ -46,6 +49,7 @@ from furnace_data.offline import fetch_offline_report as _fetch_offline_report_d
 from furnace_data.offline import (
     resolve_offline_table_name,
 )
+from utils.settings import settings
 from utils.shift_windows import shift_window_naive
 
 # CONFIG
@@ -314,6 +318,42 @@ class ConcatArgs(BaseModel):
     )
 
 
+class WebSearchArgs(BaseModel):
+    """Validated arguments for external web search.
+
+    Web search is reserved for public/current information that is not available
+    from FurnaceMind telemetry, uploaded knowledge documents, memories, or
+    internal report tools.
+    """
+
+    query: str = Field(
+        min_length=2,
+        max_length=500,
+        description="Focused public web search query.",
+    )
+    limit: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=10,
+        description="Optional maximum number of search results to return.",
+    )
+
+
+class WebScrapeIngestArgs(BaseModel):
+    """Validated arguments for approved external knowledge ingestion.
+
+    Scrape ingestion is intentionally separate from chat-time web search. It
+    should be used only when a user/admin explicitly asks FurnaceMind to add a
+    specific public URL into the shared knowledge base.
+    """
+
+    url: str = Field(
+        min_length=8,
+        max_length=2048,
+        description="Approved absolute http/https URL to scrape and index into shared FurnaceMind knowledge.",
+    )
+
+
 def _current_artifact_turn_id() -> str | None:
     """Return the active chat-turn id used for artifact ownership.
 
@@ -508,6 +548,121 @@ def _ml_column_summary(df: pd.DataFrame) -> str:
                 f"  {grp} ({len(cols)}): {', '.join(cols[:6])}"
                 + (" …" if len(cols) > 6 else "")
             )
+    return "\n".join(lines)
+
+
+def _is_web_search_enabled() -> bool:
+    """Return whether this FurnaceMind browser session allows live web search."""
+    return bool(st.session_state.get("fm_web_search_enabled", False))
+
+
+def web_search(*, query: str, limit: int | None = None) -> str:
+    """Search the public web for current or external reference information.
+
+    Args:
+        query: Focused search query generated from the user request.
+        limit: Optional number of results to return, clamped by configuration.
+
+    Returns:
+        Tool-formatted search results with source URLs, an empty-result note, or
+        a graceful unavailable message when the provider is not configured or is
+        temporarily unreachable.
+    """
+    params = {"query": query, "limit": limit}
+    try:
+        args = WebSearchArgs.model_validate(params)
+        if not _is_web_search_enabled():
+            return (
+                "web_search disabled: Web search is turned off for this session. "
+                "Turn on Web search in the FurnaceMind sidebar to fetch "
+                "current external sources."
+            )
+        return search_web(args.query, limit=args.limit)
+    except ValidationError as exc:
+        _append_tool_error(tool_name="web_search", params=params, error=str(exc))
+        return f"web_search Error: {exc}"
+
+
+def web_scrape_ingest(*, url: str) -> str:
+    """Scrape an approved URL and index it as shared MRAG knowledge.
+
+    This tool is for admin/background ingestion flows, not normal web Q&A. It
+    reuses the same knowledge store, embedding client, and SQL repositories used
+    by uploaded knowledge documents so scraped technical references are retrieved
+    through ``search_knowledge_docs`` later.
+
+    Args:
+        url: Approved absolute public URL to ingest.
+
+    Returns:
+        A structured status string describing the indexed document, or a clear
+        unavailable/no-content/error message that does not crash the chat.
+    """
+    params = {"url": url}
+    try:
+        args = WebScrapeIngestArgs.model_validate(params)
+    except ValidationError as exc:
+        _append_tool_error(tool_name="web_scrape_ingest", params=params, error=str(exc))
+        return f"web_scrape_ingest Error: {exc}"
+
+    if not re.match(r"^https?://", args.url.strip(), flags=re.IGNORECASE):
+        message = "URL must be an absolute http/https URL."
+        _append_tool_error(tool_name="web_scrape_ingest", params=params, error=message)
+        return f"web_scrape_ingest Error: {message}"
+    if not settings.web_scrape.ingest_enabled:
+        return (
+            "web_scrape_ingest disabled: set WEB_SCRAPE_INGEST_ENABLED=true "
+            "to allow approved URLs to be stored in shared knowledge."
+        )
+
+    knowledge_store = st.session_state.get("knowledge_store")
+    embedding_client = st.session_state.get("knowledge_embedding_client")
+    user_id = st.session_state.get("fm_user_id")
+    document_repository = st.session_state.get("knowledge_document_repository")
+    chunk_repository = st.session_state.get("knowledge_chunk_repository")
+
+    if knowledge_store is None:
+        return "web_scrape_ingest unavailable: Knowledge store is not initialized."
+    if embedding_client is None:
+        return "web_scrape_ingest unavailable: Knowledge embedding client is not initialized."
+
+    try:
+        result = ingest_external_knowledge_url(
+            args.url,
+            knowledge_store=knowledge_store,
+            embedding_client=embedding_client,
+            user_id=user_id,
+            document_repository=document_repository,
+            chunk_repository=chunk_repository,
+        )
+    except Exception as exc:
+        _append_tool_error(
+            tool_name="web_scrape_ingest",
+            params=params,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        return f"web_scrape_ingest Error: {type(exc).__name__}: {exc}"
+
+    if result.status in {"indexed", "already_indexed"}:
+        lines = [
+            f"Status: {result.status}",
+            f"URL: {result.url}",
+            f"Filename: {result.filename or 'unknown'}",
+            f"Document ID: {result.document_id or 'unknown'}",
+            f"SQL document ID: {result.sql_document_id or 'not persisted'}",
+            f"Chunks indexed: {result.chunk_count}",
+            f"Qdrant collection: {result.qdrant_collection or 'unknown'}",
+            "Next: use search_knowledge_docs to retrieve this source in future answers.",
+        ]
+        return "\n".join(lines)
+
+    lines = [
+        f"Status: {result.status}",
+        f"URL: {result.url}",
+        f"Reason: {result.error or 'No indexable content returned.'}",
+    ]
+    if result.filename:
+        lines.append(f"Filename: {result.filename}")
     return "\n".join(lines)
 
 
@@ -1213,11 +1368,53 @@ def get_openai_tool_schemas() -> list[dict]:
             "type": "function",
             "function": {
                 "name": "search_knowledge_docs",
-                "description": "Search uploaded multimodal knowledge documents (SOPs, manuals, specs, images, slides, tables, scanned pages).",
+                "description": "Search shared FurnaceMind MRAG knowledge, including uploaded multimodal documents and already-ingested web sources (SOPs, manuals, specs, images, slides, tables, scanned pages, indexed URLs).",
                 "parameters": {
                     "type": "object",
                     "properties": {"query": {"type": "string"}},
                     "required": ["query"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the public web for current, external, or source-attributed information that is not available in FurnaceMind telemetry, uploaded documents, memory, or internal reports.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Focused public web search query.",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "description": "Optional maximum number of search results to return.",
+                        },
+                    },
+                    "required": ["query"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "web_scrape_ingest",
+                "description": "Scrape one approved public URL and index it into shared FurnaceMind MRAG knowledge. Use only when the user/admin explicitly asks to ingest, index, or add a specific URL as shared knowledge; do not use for normal web Q&A.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Approved absolute http/https URL to scrape and store as shared knowledge.",
+                        },
+                    },
+                    "required": ["url"],
                     "additionalProperties": False,
                 },
             },
@@ -1365,6 +1562,10 @@ def execute_openai_tool_call(*, name: str, arguments: Dict[str, Any]) -> str:
         return search_shift_history.invoke(arguments)
     if name == "search_knowledge_docs":
         return search_knowledge_docs.invoke(arguments)
+    if name == "web_search":
+        return web_search(**arguments)
+    if name == "web_scrape_ingest":
+        return web_scrape_ingest(**arguments)
     if name == "render_heatload_plot":
         return render_heatload_plot.invoke(arguments)
     if name == "execute_python_plot":

--- a/src/agents/furnacemind/ai_cooperate_page.py
+++ b/src/agents/furnacemind/ai_cooperate_page.py
@@ -23,6 +23,7 @@ from agents.furnacemind.context import SystemPromptContext
 from agents.furnacemind.skill_registry import SkillRegistry
 from agents.furnacemind.skill_vector_store import SkillVectorStore
 from agents.furnacemind.skills import SkillEngine
+from agents.furnacemind.web_search import web_search_configuration_error
 from agents.llm.llm_client import OpenRouterClient
 from agents.memory import fm_memory
 from agents.memory.conversation_history import ConversationHistoryStore
@@ -601,7 +602,8 @@ def _render_web_search_toggle() -> bool:
         ``True`` when live web search is enabled for the current Streamlit
         session; otherwise ``False``.
     """
-    web_search_available = bool(settings.web_search.api_key)
+    unavailable_reason = web_search_configuration_error()
+    web_search_available = unavailable_reason is None
     if not web_search_available:
         st.session_state["fm_web_search_enabled"] = False
 
@@ -615,13 +617,14 @@ def _render_web_search_toggle() -> bool:
         ),
     )
     if not web_search_available:
-        st.sidebar.caption("Web search unavailable: Brave API key is not configured.")
-    elif enabled:
-        st.sidebar.caption("Web search on: current external questions can use Brave.")
+        st.sidebar.caption(unavailable_reason or "Web search is unavailable.")
     else:
-        st.sidebar.caption(
-            "Web search off: answers use internal tools and stored knowledge."
-        )
+        used, limit = furnace_tools.web_search_session_usage()
+        remaining = max(0, limit - used)
+        if remaining:
+            st.sidebar.caption(f"{remaining} of {limit} searches remaining")
+        else:
+            st.sidebar.caption("Session search limit reached")
     return bool(enabled)
 
 

--- a/src/agents/furnacemind/ai_cooperate_page.py
+++ b/src/agents/furnacemind/ai_cooperate_page.py
@@ -590,6 +590,41 @@ def _render_reasoning_selector() -> str:
     return normalize_openrouter_reasoning_level(selected)
 
 
+def _render_web_search_toggle() -> bool:
+    """Render the session toggle that controls live public-web search.
+
+    The toggle only gates the chat-time ``web_search`` tool. It does not affect
+    uploaded knowledge retrieval or deliberate URL scrape/index actions, which
+    remain explicit storage operations.
+
+    Returns:
+        ``True`` when live web search is enabled for the current Streamlit
+        session; otherwise ``False``.
+    """
+    web_search_available = bool(settings.web_search.api_key)
+    if not web_search_available:
+        st.session_state["fm_web_search_enabled"] = False
+
+    enabled = st.sidebar.toggle(
+        "Web search",
+        key="fm_web_search_enabled",
+        disabled=not web_search_available,
+        help=(
+            "Allow FurnaceMind to search the public web for current external "
+            "sources. Stored knowledge and URL ingestion are handled separately."
+        ),
+    )
+    if not web_search_available:
+        st.sidebar.caption("Web search unavailable: Brave API key is not configured.")
+    elif enabled:
+        st.sidebar.caption("Web search on: current external questions can use Brave.")
+    else:
+        st.sidebar.caption(
+            "Web search off: answers use internal tools and stored knowledge."
+        )
+    return bool(enabled)
+
+
 def _render_conversation_controls(
     *,
     context: SystemPromptContext,
@@ -697,6 +732,7 @@ def render_ai_cooperate(*, field_labels: dict) -> None:  # noqa: ARG001
     memory_summary_token_limit = settings.memory_summary_token_limit
 
     st.session_state["knowledge_store"] = knowledge_store
+    st.session_state["knowledge_embedding_client"] = embedding_client
     st.session_state["fm_user_id"] = user_id
     if document_repository is not None:
         st.session_state["knowledge_document_repository"] = document_repository
@@ -717,6 +753,7 @@ def render_ai_cooperate(*, field_labels: dict) -> None:  # noqa: ARG001
         st.session_state.chat_history = []
     st.session_state.setdefault("fm_artifact_store", {})
     selected_reasoning_level = _render_reasoning_selector()
+    _render_web_search_toggle()
 
     if not user_id:
         history_store = None

--- a/src/agents/furnacemind/graph.py
+++ b/src/agents/furnacemind/graph.py
@@ -46,6 +46,8 @@ _TOOL_LABELS: dict[str, str] = {
     "load_static_shift_data": "Loading shift data...",
     "search_shift_history": "Searching shift history...",
     "search_knowledge_docs": "Searching knowledge docs...",
+    "web_search": "Searching web...",
+    "web_scrape_ingest": "Indexing web source...",
     "execute_python_plot": "Generating plot...",
 }
 

--- a/src/agents/furnacemind/prompts.py
+++ b/src/agents/furnacemind/prompts.py
@@ -27,7 +27,10 @@ How to respond (keep it short and easy to scan):
 Tool & routing discipline:
 - First decide the user's intent before calling a tool.
 - Generic capability/help questions (for example "what can you help me analyze?") do not need tools and must not cite uploaded documents.
-- Uploaded-document questions (uploaded files, PDFs, PPT/PPTX, slides, pages, document charts, SOPs, procedures, specs, policies, BMO analysis) -> use search_knowledge_docs.
+- Current/latest external information, public documentation, vendor/reference lookups, or web-sourced facts not available internally -> use web_search only when Web search is enabled, and cite returned URLs. If it is disabled, say Web search is off and ask the user to enable it.
+- Approved URL ingestion requests (for example "index this URL", "add this article to knowledge", or "scrape this SOP into shared knowledge") -> use web_scrape_ingest only when the user provides a specific URL and explicitly asks to store it.
+- Do not use web_search for FurnaceMind telemetry, uploaded documents, memory, feedback lessons, or internal reports.
+- Uploaded/shared-knowledge questions (uploaded files, PDFs, PPT/PPTX, slides, pages, document charts, SOPs, procedures, specs, policies, BMO analysis, or already-ingested/indexed web sources) -> use search_knowledge_docs.
 - A chart inside an uploaded document is document evidence -> use search_knowledge_docs, not execute_python_plot.
 - Live behavior / trends / "last N hours" -> use fetch_online_data or fetch_ml_data.
 - Heatload checks/trends -> fetch_online_data first, then use render_heatload_plot for the chart instead of execute_python_plot.
@@ -42,11 +45,14 @@ Keep the tone professional, concise, and operator-friendly.\
 # ── Tool-calling policy injected alongside the system prompt ─────────────────
 
 TOOL_POLICY = """\
-You may call tools. Use tools whenever you need live telemetry, offline reports, knowledge docs, or plots. Never guess numeric values. Do NOT call search_shift_history unless the user explicitly asks for saved shift reports because shift reports are not persisted in this deployment and the tool will return empty results.
+You may call tools. Use tools whenever you need live telemetry, offline reports, knowledge docs, web search, or plots. Never guess numeric values. Do NOT call search_shift_history unless the user explicitly asks for saved shift reports because shift reports are not persisted in this deployment and the tool will return empty results.
 
 INTENT ROUTING (do this before any tool call):
 - Generic assistant capability questions do not require tools. Answer generally without citing uploaded documents.
-- Uploaded-document questions include uploaded files, PDFs, PPT/PPTX, slides, pages, document charts, SOPs, procedures, specs, policies, BMO analysis, or follow-up questions clearly asking about facts from an uploaded document. Use search_knowledge_docs first.
+- Current/latest external or public-web questions include vendor docs, standards, public references, market/news/current facts, and anything not available in FurnaceMind internal sources. Use web_search only when Web search is enabled, and cite returned URLs. If it is disabled, say Web search is off and ask the user to enable it.
+- Use web_scrape_ingest only for explicit approved URL ingestion requests. Never call it just because a normal answer used web_search.
+- Prefer internal FurnaceMind tools over web_search for plant telemetry, uploaded documents, memories, feedback lessons, and internal reports.
+- Uploaded/shared-knowledge questions include uploaded files, PDFs, PPT/PPTX, slides, pages, document charts, SOPs, procedures, specs, policies, BMO analysis, ingested/indexed web sources, or follow-up questions clearly asking about facts from stored knowledge. Use search_knowledge_docs first.
 - If the user asks about a chart/figure/table inside an uploaded document, use search_knowledge_docs. Do not create a new furnace telemetry plot for document visuals.
 - Explicit operational plot/chart/trend requests require data first, then exactly one final visible figure. For heatload checks/trends, fetch heatload_delta_t/temperature_profile data and call render_heatload_plot. For other plots, call execute_python_plot once.
 - For execute_python_plot, never include import statements or fig.show(). The sandbox already provides df, pd, px, go, make_subplots, and np; start directly with column selection and fig creation. For multi-series line charts, give each trace a clear name and avoid assigning one repeated color to all traces.
@@ -65,6 +71,8 @@ DATA SOURCE ROUTING (follow this order):
    - Types: HM_SLAG, CHARGE, RAW_MATERIAL_COMPOSITION (Bunker), RAW_MATERIAL_STRENGTH, DPR.
 4. concat_datasets — stitch static + online portions after a dual-fetch.
 5. merge_furnace_data — align offline onto online/static timestamps (column-wise join).
+6. web_search - public/current/external information only; cite the returned URL fields for web-derived claims.
+7. web_scrape_ingest - approved URL ingestion only; stores the scraped source as shared MRAG knowledge for later retrieval.
 
 COLUMN NAMING:
 - ML static dataset uses ML names: 'ACT. FUEL RATEKG/THM.', 'CHEM_PCT_SI', 'FURNACETOPGASANALYSISCO2ETACO'.
@@ -73,8 +81,18 @@ COLUMN NAMING:
 
 OFFLINE CADENCE DEFAULTS: HM_SLAG/CHARGE => 1h, RAW_MATERIAL_COMPOSITION/RAW_MATERIAL_STRENGTH => 8h, DPR => 1d.
 
+WEB SEARCH ANSWERING:
+- Use web_search only for public/current/external information and only when the sidebar Web search toggle is enabled. Do not treat web results as plant evidence.
+- Cite source URLs returned by web_search for every web-derived claim. Do not cite URLs that were not returned by the tool.
+- If web_search is disabled, unavailable, or returns no results, say that clearly and continue only with internal context when it is sufficient.
+
+WEB SCRAPE INGESTION:
+- Use web_scrape_ingest only when the user/admin explicitly asks to ingest, index, scrape, or add a specific URL into shared FurnaceMind knowledge.
+- Do not call web_scrape_ingest for normal Q&A, current-news answers, or plant analysis.
+- After successful ingestion, future questions about that ingested/indexed web source should use search_knowledge_docs and cite the ingested source label. Do not use web_search for already-ingested sources.
+
 KNOWLEDGE DOC ANSWERING:
-- Do not call search_knowledge_docs for generic capability questions or normal furnace telemetry questions unless the user mentions an uploaded/shared document, file, slide, page, SOP, manual, spec, policy, BMO analysis, or clearly asks a document-derived follow-up.
+- Do not call search_knowledge_docs for generic capability questions or normal furnace telemetry questions unless the user mentions an uploaded/shared document, file, slide, page, SOP, manual, spec, policy, BMO analysis, ingested/indexed web source, or clearly asks a stored-knowledge follow-up.
 - When search_knowledge_docs returns uploaded document chunks, answer only from those chunks and cite the exact source labels returned by the tool, such as slide/page/sheet.
 - Prefer the most direct matching chunk over adjacent summary chunks. For model accuracy questions, report the exact model name and metrics. For driver/root-cause questions, use feature-importance or sensitivity chunks when present.
 - Never cite semantic memory, feedback lessons, or prior chat as evidence for uploaded-document facts. Evidence must be the retrieved document source label.

--- a/src/agents/furnacemind/web_ingestion.py
+++ b/src/agents/furnacemind/web_ingestion.py
@@ -1,0 +1,550 @@
+"""Ingest approved public web pages into shared FurnaceMind knowledge.
+
+This module is deliberately separate from the chat-time ``web_search`` tool.
+Search returns current web results without storing anything. External knowledge
+ingestion is an admin/background workflow: it sends an approved public URL to
+Jina Reader, stores the returned Markdown bytes on ``memory_documents`` when SQL
+repositories are available, chunks the text, embeds it, and writes the chunks
+into the shared MRAG knowledge collection.
+
+Brave is used only for search. Jina Reader is used for URL reading/scraping so
+messy public HTML is converted into cleaner Markdown before it reaches the
+existing knowledge ingestion pipeline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Any, Callable, Iterable
+from urllib.parse import urlparse
+
+import httpx
+
+from agents.multimodal.ingestion import process_file
+from utils.settings import WebScrapeConfig, settings
+
+logger = logging.getLogger(__name__)
+_FILENAME_SAFE_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+_INLINE_WS_RE = re.compile(r"[ \t\f\v]+")
+_PROVIDER_NAME = "jina_reader"
+_MARKDOWN_CONTENT_MARKER = "Markdown Content:"
+_TITLE_RE = re.compile(r"^Title:\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+_HEADING_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_URL_SOURCE_RE = re.compile(r"^URL Source:\s*.+$", re.IGNORECASE | re.MULTILINE)
+_READER_HEADERS = {
+    "Accept": "text/plain, text/markdown;q=0.9, */*;q=0.8",
+    "User-Agent": "FurnaceMind-JinaReader/1.0",
+    "X-Return-Format": "markdown",
+}
+
+
+@dataclass(frozen=True)
+class ScrapedWebPage:
+    """Clean Markdown extracted from one approved public URL.
+
+    Attributes:
+        url: Original source URL requested for scraping.
+        title: Best-effort page title parsed from Jina Reader output or URL.
+        content: Markdown content retained for MRAG ingestion.
+        provider: Scraper implementation name, currently ``"jina_reader"``.
+        fetched_at: UTC timestamp when the page was read.
+        sha256: SHA-256 digest of the retained Markdown content.
+        content_type: MIME-like type used when storing the source bytes in SQL.
+    """
+
+    url: str
+    title: str
+    content: str
+    provider: str
+    fetched_at: datetime
+    sha256: str
+    content_type: str = "text/markdown; charset=utf-8"
+
+
+@dataclass(frozen=True)
+class WebScrapeResponse:
+    """Normalized reader response for chat tools and background jobs.
+
+    ``page`` is populated only for successful reads. ``error`` is populated for
+    invalid URLs, empty Reader output, timeouts, HTTP failures, and parser
+    failures. Callers can report missing-data notes without crashing the
+    conversation or ingestion job.
+    """
+
+    url: str
+    provider: str
+    page: ScrapedWebPage | None = None
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Return True when Jina Reader produced usable page content."""
+        return self.page is not None and not self.error
+
+
+@dataclass(frozen=True)
+class ExternalKnowledgeIngestionResult:
+    """Outcome of storing one read web page in shared knowledge.
+
+    Attributes:
+        url: Source URL requested for ingestion.
+        status: ``"indexed"``, ``"already_indexed"``, ``"no_content"``, or
+            ``"unavailable"``.
+        document_id: Stable MRAG document id from generated chunks, if indexed.
+        sql_document_id: SQL ``memory_documents`` row id, when SQL persistence ran.
+        filename: Generated Markdown filename used in citations and SQL metadata.
+        chunk_count: Number of Qdrant chunks written.
+        qdrant_collection: Knowledge collection used for vector storage.
+        error: Optional missing-data or provider failure message.
+    """
+
+    url: str
+    status: str
+    document_id: str | None = None
+    sql_document_id: str | None = None
+    filename: str | None = None
+    chunk_count: int = 0
+    qdrant_collection: str | None = None
+    error: str | None = None
+
+
+class JinaReaderProvider:
+    """Jina Reader client for approved public web pages.
+
+    The provider accepts only absolute ``http`` and ``https`` source URLs, calls
+    the configured Jina Reader endpoint, and converts the returned text into the
+    stable ``ScrapedWebPage`` object consumed by the existing MRAG ingestion
+    pipeline. Network and provider failures are converted to
+    ``WebScrapeResponse(error=...)`` so chat and ingestion jobs can continue
+    safely.
+    """
+
+    def __init__(
+        self,
+        config: WebScrapeConfig,
+        *,
+        client_factory: Callable[..., httpx.Client] = httpx.Client,
+    ) -> None:
+        """Create a provider from runtime config and an injectable HTTP client."""
+        self.config = config
+        self.client_factory = client_factory
+        self.provider = _PROVIDER_NAME
+
+    def fetch(self, url: str) -> WebScrapeResponse:
+        """Read and normalize one public web page with Jina Reader.
+
+        Args:
+            url: Absolute ``http`` or ``https`` source URL approved for ingestion.
+
+        Returns:
+            A successful ``WebScrapeResponse`` with ``page`` populated, or an
+            unavailable response with ``error`` explaining why no content was
+            indexed.
+        """
+        clean_url = _normalize_source_url(url)
+        if not clean_url:
+            return WebScrapeResponse(
+                url=str(url or "").strip(),
+                provider=self.provider,
+                error="Only absolute http/https URLs can be read by Jina Reader.",
+            )
+        logger.info(
+            "web_scrape_request",
+            extra={"provider": self.provider, "url": clean_url},
+        )
+        response = self._request_with_retries(clean_url)
+        if response.error:
+            logger.warning(
+                "web_scrape_failed",
+                extra={
+                    "provider": self.provider,
+                    "url": clean_url,
+                    "error": response.error,
+                },
+            )
+            return response
+        logger.info(
+            "web_scrape_response",
+            extra={
+                "provider": self.provider,
+                "url": clean_url,
+                "chars": len(response.page.content) if response.page else 0,
+            },
+        )
+        return response
+
+    def _request_with_retries(self, url: str) -> WebScrapeResponse:
+        """Execute one Jina Reader request with bounded retry/backoff."""
+        last_error = "Jina Reader request failed."
+        attempts = max(0, self.config.max_retries) + 1
+        reader_url = _reader_request_url(self.config.endpoint, url)
+        headers = _reader_headers(self.config.api_key)
+        for attempt in range(attempts):
+            try:
+                with self.client_factory(timeout=self.config.timeout_seconds) as client:
+                    response = client.get(reader_url, headers=headers)
+                    response.raise_for_status()
+                    page = _parse_jina_reader_response(
+                        url=url,
+                        raw_text=response.text,
+                        provider=self.provider,
+                        max_chars=self.config.max_chars,
+                    )
+                    return WebScrapeResponse(url=url, provider=self.provider, page=page)
+            except ValueError as exc:
+                last_error = str(exc)
+            except httpx.TimeoutException as exc:
+                last_error = f"Jina Reader request timed out: {exc}"
+            except httpx.HTTPStatusError as exc:
+                status_code = getattr(exc.response, "status_code", "unknown")
+                last_error = f"Jina Reader returned HTTP {status_code}."
+            except httpx.RequestError as exc:
+                last_error = f"Jina Reader request failed: {exc}"
+            except Exception as exc:
+                last_error = f"Jina Reader request failed: {type(exc).__name__}: {exc}"
+
+            if attempt < attempts - 1:
+                time.sleep(min(0.5 * (2**attempt), 3.0))
+
+        return WebScrapeResponse(url=url, provider=self.provider, error=last_error)
+
+
+def build_web_scrape_provider(
+    config: WebScrapeConfig | None = None,
+) -> JinaReaderProvider:
+    """Build the configured external knowledge reader provider.
+
+    Raises:
+        ValueError: If ``WEB_SCRAPE_PROVIDER`` names an unsupported provider.
+    """
+    cfg = config or settings.web_scrape
+    if cfg.provider != _PROVIDER_NAME:
+        raise ValueError(f"Unsupported WEB_SCRAPE_PROVIDER: {cfg.provider}")
+    return JinaReaderProvider(cfg)
+
+
+def scrape_web_page(url: str) -> WebScrapeResponse:
+    """Read one URL through Jina Reader without storing it."""
+    try:
+        provider = build_web_scrape_provider()
+        return provider.fetch(url)
+    except Exception as exc:
+        return WebScrapeResponse(
+            url=str(url or "").strip(),
+            provider=_PROVIDER_NAME,
+            error=f"Jina Reader unavailable: {type(exc).__name__}: {exc}",
+        )
+
+
+def ingest_external_knowledge_url(
+    url: str,
+    *,
+    knowledge_store: Any,
+    embedding_client: Any,
+    user_id: str | None = None,
+    document_repository: Any | None = None,
+    chunk_repository: Any | None = None,
+    provider: JinaReaderProvider | None = None,
+) -> ExternalKnowledgeIngestionResult:
+    """Read an approved URL and index it into shared MRAG knowledge.
+
+    ``user_id`` is recorded as the uploader/audit owner when SQL persistence is
+    available. Retrieval stays shared because FurnaceMind knowledge search uses
+    active document ids and does not require user-scoped Qdrant filtering.
+    """
+    scrape_provider = provider or build_web_scrape_provider()
+    response = scrape_provider.fetch(url)
+    if response.error or response.page is None:
+        return ExternalKnowledgeIngestionResult(
+            url=response.url,
+            status="unavailable",
+            error=response.error or "No page content returned by Jina Reader.",
+        )
+
+    page = response.page
+    existing_document = _find_existing_external_document(
+        document_repository=document_repository,
+        source_url=page.url,
+        sha256=page.sha256,
+    )
+    if existing_document is not None:
+        metadata = getattr(existing_document, "metadata_json", None)
+        metadata = metadata if isinstance(metadata, dict) else {}
+        return ExternalKnowledgeIngestionResult(
+            url=page.url,
+            status="already_indexed",
+            document_id=str(metadata.get("document_id") or "") or None,
+            sql_document_id=str(getattr(existing_document, "document_id", "") or "")
+            or None,
+            filename=str(getattr(existing_document, "filename", "") or "") or None,
+            chunk_count=int(metadata.get("chunk_count") or 0),
+            qdrant_collection=str(
+                getattr(existing_document, "qdrant_collection", "") or ""
+            )
+            or None,
+            error="Source URL or content hash is already indexed in shared knowledge.",
+        )
+
+    filename = _scraped_filename(page)
+    upload = _ScrapedUpload(
+        page.content.encode("utf-8"),
+        name=filename,
+        content_type=page.content_type,
+    )
+    source_metadata = {
+        "source_type": "web_scrape",
+        "source_url": page.url,
+        "title": page.title,
+        "web_title": page.title,
+        "provider": page.provider,
+        "fetched_at": page.fetched_at.isoformat(),
+        "sha256": page.sha256,
+    }
+    parts = process_file(
+        upload,
+        knowledge_store,
+        embedding_client,
+        user_id=user_id,
+        document_repository=document_repository,
+        chunk_repository=chunk_repository,
+        source_metadata=source_metadata,
+    )
+    if not parts:
+        return ExternalKnowledgeIngestionResult(
+            url=page.url,
+            status="no_content",
+            filename=filename,
+            error="Jina Reader output did not produce any indexable chunks.",
+        )
+
+    sql_document_id = _find_sql_document_id(
+        document_repository=document_repository,
+        user_id=user_id,
+        mrag_document_id=parts[0].document_id,
+    )
+    return ExternalKnowledgeIngestionResult(
+        url=page.url,
+        status="indexed",
+        document_id=parts[0].document_id,
+        sql_document_id=sql_document_id,
+        filename=filename,
+        chunk_count=len(parts),
+        qdrant_collection=getattr(knowledge_store, "collection_name", None),
+    )
+
+
+def ingest_external_knowledge_urls(
+    urls: Iterable[str],
+    *,
+    knowledge_store: Any,
+    embedding_client: Any,
+    user_id: str | None = None,
+    document_repository: Any | None = None,
+    chunk_repository: Any | None = None,
+    provider: JinaReaderProvider | None = None,
+) -> list[ExternalKnowledgeIngestionResult]:
+    """Index multiple approved URLs, returning one result per URL."""
+    return [
+        ingest_external_knowledge_url(
+            url,
+            knowledge_store=knowledge_store,
+            embedding_client=embedding_client,
+            user_id=user_id,
+            document_repository=document_repository,
+            chunk_repository=chunk_repository,
+            provider=provider,
+        )
+        for url in urls
+    ]
+
+
+class _ScrapedUpload(BytesIO):
+    """File-like wrapper that lets web Markdown reuse ``process_file`` unchanged."""
+
+    def __init__(self, data: bytes, *, name: str, content_type: str) -> None:
+        super().__init__(data)
+        self.name = name
+        self.type = content_type
+
+
+def _normalize_source_url(url: str) -> str | None:
+    """Return a clean absolute source URL, or ``None`` when unsupported."""
+    clean_url = str(url or "").strip()
+    parsed = urlparse(clean_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return clean_url
+
+
+def _reader_headers(api_key: str | None) -> dict[str, str]:
+    """Return headers for a Jina Reader request without mutating defaults."""
+    headers = dict(_READER_HEADERS)
+    clean_key = str(api_key or "").strip()
+    if clean_key:
+        headers["Authorization"] = f"Bearer {clean_key}"
+    return headers
+
+
+def _reader_request_url(endpoint: str, source_url: str) -> str:
+    """Return the Jina Reader URL for one source URL."""
+    base = str(endpoint or "https://r.jina.ai").strip().rstrip("/")
+    return f"{base}/{source_url}"
+
+
+def _parse_jina_reader_response(
+    *,
+    url: str,
+    raw_text: str,
+    provider: str,
+    max_chars: int,
+) -> ScrapedWebPage:
+    """Convert Jina Reader Markdown output into stored source content."""
+    text = str(raw_text or "").strip()
+    if not text:
+        raise ValueError("Jina Reader returned empty content.")
+
+    title = _extract_reader_title(text) or _fallback_title(url)
+    body = _extract_reader_body(text)
+    if max_chars > 0 and len(body) > max_chars:
+        body = body[:max_chars].rstrip()
+    if not body:
+        raise ValueError("Jina Reader returned no usable page content.")
+
+    content = f"# {title}\n\nSource URL: {url}\n\n{body}"
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return ScrapedWebPage(
+        url=url,
+        title=title,
+        content=content,
+        provider=provider,
+        fetched_at=datetime.now(timezone.utc),
+        sha256=digest,
+    )
+
+
+def _extract_reader_title(text: str) -> str | None:
+    """Return a title from Jina metadata or the first Markdown heading."""
+    metadata_match = _TITLE_RE.search(text)
+    if metadata_match:
+        title = _normalize_inline_text(metadata_match.group(1))
+        if title:
+            return title
+    heading_match = _HEADING_RE.search(text)
+    if heading_match:
+        title = _normalize_inline_text(heading_match.group(1))
+        if title:
+            return title
+    return None
+
+
+def _extract_reader_body(text: str) -> str:
+    """Return page Markdown from Jina Reader output without metadata wrappers."""
+    _, marker, remainder = text.partition(_MARKDOWN_CONTENT_MARKER)
+    body = remainder if marker else text
+    body = _TITLE_RE.sub("", body)
+    body = _URL_SOURCE_RE.sub("", body)
+    body = body.replace(_MARKDOWN_CONTENT_MARKER, "")
+    return _normalize_markdown(body)
+
+
+def _normalize_markdown(value: str) -> str:
+    """Trim noisy whitespace while preserving readable Markdown line breaks."""
+    normalized_lines: list[str] = []
+    blank_pending = False
+    for raw_line in str(value or "").replace("\xa0", " ").splitlines():
+        line = _INLINE_WS_RE.sub(" ", raw_line).rstrip()
+        if not line.strip():
+            blank_pending = bool(normalized_lines)
+            continue
+        if blank_pending:
+            normalized_lines.append("")
+            blank_pending = False
+        normalized_lines.append(line.strip())
+    return "\n".join(normalized_lines).strip()
+
+
+def _normalize_inline_text(value: str) -> str:
+    """Collapse a short title-like value into a single readable line."""
+    return " ".join(str(value or "").split()).strip(" #")
+
+
+def _fallback_title(url: str) -> str:
+    """Build a readable title from the URL host/path when Reader has no title."""
+    parsed = urlparse(url)
+    label = parsed.netloc or url
+    path = parsed.path.strip("/").rsplit("/", 1)[-1]
+    if path:
+        label = f"{label} {path}"
+    return label.replace("-", " ").replace("_", " ").strip() or "web source"
+
+
+def _scraped_filename(page: ScrapedWebPage) -> str:
+    """Return a deterministic Markdown filename for a read web page."""
+    slug_source = page.title or _fallback_title(page.url)
+    slug = _FILENAME_SAFE_RE.sub("_", slug_source).strip("._-").lower()
+    slug = slug[:80] or "web_source"
+    return f"web_{page.sha256[:12]}_{slug}.md"
+
+
+def _find_existing_external_document(
+    *,
+    document_repository: Any | None,
+    source_url: str,
+    sha256: str,
+) -> Any | None:
+    """Return an active SQL document matching a source URL or content digest."""
+    if document_repository is None or not hasattr(
+        document_repository, "list_documents"
+    ):
+        return None
+    try:
+        documents = document_repository.list_documents(user_id=None, active_only=True)
+    except TypeError:
+        try:
+            documents = document_repository.list_documents(user_id=None)
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+    normalized_url = _normalize_source_url(source_url) or str(source_url or "").strip()
+    for document in documents:
+        metadata = getattr(document, "metadata_json", None)
+        metadata = metadata if isinstance(metadata, dict) else {}
+        metadata_url = _normalize_source_url(str(metadata.get("source_url") or ""))
+        metadata_sha = str(metadata.get("sha256") or "").strip().lower()
+        row_sha = str(getattr(document, "sha256", "") or "").strip().lower()
+        if metadata_url and metadata_url == normalized_url:
+            return document
+        if sha256 and sha256.lower() in {metadata_sha, row_sha}:
+            return document
+    return None
+
+
+def _find_sql_document_id(
+    *,
+    document_repository: Any | None,
+    user_id: str | None,
+    mrag_document_id: str,
+) -> str | None:
+    """Best-effort lookup of the SQL row created for an ingested page."""
+    if document_repository is None or not hasattr(
+        document_repository, "list_documents"
+    ):
+        return None
+    try:
+        for document in document_repository.list_documents(user_id=user_id):
+            metadata = getattr(document, "metadata_json", None)
+            if isinstance(metadata, dict) and str(metadata.get("document_id")) == str(
+                mrag_document_id
+            ):
+                return str(getattr(document, "document_id", "") or "") or None
+    except Exception:
+        return None
+    return None

--- a/src/agents/furnacemind/web_search.py
+++ b/src/agents/furnacemind/web_search.py
@@ -1,0 +1,294 @@
+"""Provider-neutral web search support for FurnaceMind tools.
+
+The FurnaceMind agent exposes a single ``web_search`` tool to the model. This
+module keeps the provider-specific HTTP details behind a small interface so the
+current Brave Search integration can be replaced later without changing prompt
+routing or the tool registry.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import httpx
+
+from utils.settings import WebSearchConfig, settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WebSearchResult:
+    """One normalized web search result returned to FurnaceMind.
+
+    Attributes:
+        title: Human-readable result title.
+        url: Canonical result URL used for source citation.
+        snippet: Short provider summary or page excerpt.
+    """
+
+    title: str
+    url: str
+    snippet: str
+
+
+@dataclass(frozen=True)
+class WebSearchResponse:
+    """Normalized response from any web search provider.
+
+    Attributes:
+        query: Original search query.
+        provider: Provider name, such as ``"brave"``.
+        results: Ordered normalized search results.
+        error: Optional provider/configuration error. When present, the tool
+            should return a graceful unavailable message instead of raising.
+    """
+
+    query: str
+    provider: str
+    results: list[WebSearchResult]
+    error: str | None = None
+
+    def to_tool_text(self) -> str:
+        """Render search results in a stable format for LLM tool consumption."""
+        lines = [
+            "WEB_SEARCH_RESULTS",
+            f"Provider: {self.provider}",
+            f"Query: {self.query}",
+        ]
+        if self.error:
+            lines.extend(
+                [
+                    "Status: unavailable",
+                    "Missing-data notes:",
+                    f"- {self.error}",
+                ]
+            )
+            return "\n".join(lines)
+
+        if not self.results:
+            lines.extend(
+                [
+                    "Status: no_results",
+                    "Results: none",
+                    "Missing-data notes:",
+                    "- The search provider returned no results for this query.",
+                ]
+            )
+            return "\n".join(lines)
+
+        lines.extend(["Status: ok", "Results:"])
+        for index, result in enumerate(self.results, start=1):
+            lines.extend(
+                [
+                    f"{index}. {result.title}",
+                    f"   URL: {result.url}",
+                    f"   Snippet: {result.snippet}",
+                ]
+            )
+        lines.extend(
+            [
+                "Citation guidance:",
+                "- Use the URL fields above when citing web-derived claims.",
+            ]
+        )
+        return "\n".join(lines)
+
+
+class BraveSearchProvider:
+    """HTTP client for Brave Search's web search API.
+
+    The provider returns normalized ``WebSearchResponse`` objects and never
+    raises provider/network failures to callers. Retries are intentionally small
+    and bounded by ``WebSearchConfig.max_retries`` so a slow search service does
+    not block the FurnaceMind conversation for too long.
+    """
+
+    def __init__(
+        self,
+        config: WebSearchConfig,
+        *,
+        client_factory: Callable[..., httpx.Client] = httpx.Client,
+    ) -> None:
+        """Create a Brave provider from runtime configuration.
+
+        Args:
+            config: Search settings loaded from environment variables.
+            client_factory: Injectable HTTP client factory used by tests.
+        """
+        self.config = config
+        self.client_factory = client_factory
+
+    def search(self, *, query: str, limit: int | None = None) -> WebSearchResponse:
+        """Search Brave and return normalized results.
+
+        Args:
+            query: Search query text.
+            limit: Optional per-call result cap. The effective value is clamped
+                to the configured maximum.
+
+        Returns:
+            ``WebSearchResponse`` containing results, no-result status, or a
+            graceful unavailable error.
+        """
+        clean_query = str(query or "").strip()
+        effective_limit = _effective_limit(limit, self.config.max_results)
+        if not clean_query:
+            return WebSearchResponse(
+                query=clean_query,
+                provider=self.config.provider,
+                results=[],
+                error="Search query is empty.",
+            )
+        if not self.config.api_key:
+            return WebSearchResponse(
+                query=clean_query,
+                provider=self.config.provider,
+                results=[],
+                error="BRAVE_SEARCH_API_KEY or WEB_SEARCH_API_KEY is not configured.",
+            )
+
+        logger.info(
+            "web_search_request",
+            extra={
+                "provider": self.config.provider,
+                "query": clean_query,
+                "limit": effective_limit,
+            },
+        )
+        response = self._request_with_retries(clean_query, effective_limit)
+        if response.error:
+            logger.warning(
+                "web_search_failed",
+                extra={
+                    "provider": self.config.provider,
+                    "query": clean_query,
+                    "error": response.error,
+                },
+            )
+            return response
+        logger.info(
+            "web_search_response",
+            extra={
+                "provider": self.config.provider,
+                "query": clean_query,
+                "result_count": len(response.results),
+            },
+        )
+        return response
+
+    def _request_with_retries(self, query: str, limit: int) -> WebSearchResponse:
+        """Execute one Brave request with bounded retry/backoff."""
+        last_error = "Search provider failed."
+        attempts = max(0, self.config.max_retries) + 1
+        for attempt in range(attempts):
+            try:
+                with self.client_factory(timeout=self.config.timeout_seconds) as client:
+                    response = client.get(
+                        self.config.endpoint,
+                        headers={
+                            "Accept": "application/json",
+                            "X-Subscription-Token": self.config.api_key or "",
+                        },
+                        params={
+                            "q": query,
+                            "count": limit,
+                            "text_decorations": "false",
+                        },
+                    )
+                    response.raise_for_status()
+                    return WebSearchResponse(
+                        query=query,
+                        provider=self.config.provider,
+                        results=_parse_brave_results(response.json(), limit),
+                    )
+            except httpx.TimeoutException as exc:
+                last_error = f"Search request timed out: {exc}"
+            except httpx.HTTPStatusError as exc:
+                status_code = getattr(exc.response, "status_code", "unknown")
+                last_error = f"Search provider returned HTTP {status_code}."
+            except httpx.RequestError as exc:
+                last_error = f"Search request failed: {exc}"
+            except Exception as exc:  # provider payload or client-factory errors
+                last_error = f"Search provider failed: {type(exc).__name__}: {exc}"
+
+            if attempt < attempts - 1:
+                time.sleep(min(0.25 * (2**attempt), 2.0))
+
+        return WebSearchResponse(
+            query=query,
+            provider=self.config.provider,
+            results=[],
+            error=last_error,
+        )
+
+
+def _effective_limit(limit: int | None, configured_limit: int) -> int:
+    """Return a safe result limit for one search request."""
+    try:
+        requested = int(limit) if limit is not None else int(configured_limit)
+    except (TypeError, ValueError):
+        requested = int(configured_limit)
+    return max(1, min(requested, int(configured_limit), 10))
+
+
+def _clean_text(value: Any) -> str:
+    """Convert provider text fields into single-line strings."""
+    return " ".join(str(value or "").split())
+
+
+def _parse_brave_results(payload: dict[str, Any], limit: int) -> list[WebSearchResult]:
+    """Normalize Brave Search JSON into FurnaceMind search results."""
+    raw_results = (payload.get("web") or {}).get("results") or []
+    results: list[WebSearchResult] = []
+    for raw in raw_results:
+        title = _clean_text(raw.get("title"))
+        url = _clean_text(raw.get("url"))
+        snippet = _clean_text(raw.get("description") or raw.get("snippet"))
+        if not title or not url:
+            continue
+        results.append(WebSearchResult(title=title, url=url, snippet=snippet))
+        if len(results) >= limit:
+            break
+    return results
+
+
+def build_web_search_provider(
+    config: WebSearchConfig | None = None,
+) -> BraveSearchProvider:
+    """Build the configured web search provider.
+
+    Raises:
+        ValueError: If ``WEB_SEARCH_PROVIDER`` names an unsupported provider.
+    """
+    cfg = config or settings.web_search
+    if cfg.provider != "brave":
+        raise ValueError(f"Unsupported WEB_SEARCH_PROVIDER: {cfg.provider}")
+    return BraveSearchProvider(cfg)
+
+
+def search_web(query: str, *, limit: int | None = None) -> str:
+    """Run web search through the configured provider and render tool output."""
+    try:
+        provider = build_web_search_provider()
+        response = provider.search(query=query, limit=limit)
+    except Exception as exc:
+        cfg = settings.web_search
+        response = WebSearchResponse(
+            query=str(query or "").strip(),
+            provider=cfg.provider,
+            results=[],
+            error=f"Search provider unavailable: {type(exc).__name__}: {exc}",
+        )
+        logger.warning(
+            "web_search_failed",
+            extra={
+                "provider": cfg.provider,
+                "query": str(query or "").strip(),
+                "error": response.error,
+            },
+        )
+    return response.to_tool_text()

--- a/src/agents/furnacemind/web_search.py
+++ b/src/agents/furnacemind/web_search.py
@@ -1,9 +1,9 @@
 """Provider-neutral web search support for FurnaceMind tools.
 
-The FurnaceMind agent exposes a single ``web_search`` tool to the model. This
-module keeps the provider-specific HTTP details behind a small interface so the
-current Brave Search integration can be replaced later without changing prompt
-routing or the tool registry.
+FurnaceMind exposes one ``web_search`` tool to the model. This module keeps
+provider-specific authentication, request formats, and response parsing behind
+adapters that all return the same normalized result type. Changing providers
+therefore requires configuration only; prompts and tool dispatch stay stable.
 """
 
 from __future__ import annotations
@@ -11,18 +11,24 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Callable
+from html.parser import HTMLParser
+from typing import Any, Callable, Protocol
+from urllib.parse import parse_qs, unquote, urlsplit, urlunsplit
 
 import httpx
 
-from utils.settings import WebSearchConfig, settings
+from utils.settings import (
+    WebSearchConfig,
+    normalize_web_search_provider_name,
+    settings,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class WebSearchResult:
-    """One normalized web search result returned to FurnaceMind.
+    """One normalized result returned by any configured search provider.
 
     Attributes:
         title: Human-readable result title.
@@ -41,10 +47,10 @@ class WebSearchResponse:
 
     Attributes:
         query: Original search query.
-        provider: Provider name, such as ``"brave"``.
+        provider: Canonical provider name, such as ``"brave"`` or ``"tavily"``.
         results: Ordered normalized search results.
-        error: Optional provider/configuration error. When present, the tool
-            should return a graceful unavailable message instead of raising.
+        error: Optional provider/configuration error. Provider failures are
+            represented here instead of escaping into the conversation flow.
     """
 
     query: str
@@ -98,14 +104,33 @@ class WebSearchResponse:
         return "\n".join(lines)
 
 
-class BraveSearchProvider:
-    """HTTP client for Brave Search's web search API.
+class WebSearchProvider(Protocol):
+    """Contract implemented by every FurnaceMind web-search adapter."""
 
-    The provider returns normalized ``WebSearchResponse`` objects and never
-    raises provider/network failures to callers. Retries are intentionally small
-    and bounded by ``WebSearchConfig.max_retries`` so a slow search service does
-    not block the FurnaceMind conversation for too long.
+    provider_name: str
+
+    def configuration_error(self) -> str | None:
+        """Return why this provider is unavailable, or ``None`` when ready."""
+
+    def search(self, *, query: str, limit: int | None = None) -> WebSearchResponse:
+        """Search the provider and return normalized, source-citable results."""
+
+
+WebSearchProviderFactory = Callable[[WebSearchConfig], WebSearchProvider]
+
+
+class BaseWebSearchAdapter:
+    """Share validation, logging, retries, and graceful failures across adapters.
+
+    Subclasses only define provider metadata and implement ``_perform_search``.
+    This keeps operational behavior consistent when the configured provider is
+    changed and prevents network or payload failures from crashing FurnaceMind.
     """
+
+    provider_name = ""
+    requires_api_key = True
+    api_key_environment = "WEB_SEARCH_API_KEY"
+    endpoint_environment = "WEB_SEARCH_ENDPOINT"
 
     def __init__(
         self,
@@ -113,48 +138,51 @@ class BraveSearchProvider:
         *,
         client_factory: Callable[..., httpx.Client] = httpx.Client,
     ) -> None:
-        """Create a Brave provider from runtime configuration.
-
-        Args:
-            config: Search settings loaded from environment variables.
-            client_factory: Injectable HTTP client factory used by tests.
-        """
+        """Create an adapter from runtime configuration and an HTTP client."""
         self.config = config
         self.client_factory = client_factory
 
+    def configuration_error(self) -> str | None:
+        """Return a provider-specific setup error when required values are absent."""
+        if not str(self.config.endpoint or "").strip():
+            return (
+                f"The configured '{self.provider_name}' web-search provider is "
+                "missing its endpoint. Set "
+                f"{self.endpoint_environment} or WEB_SEARCH_ENDPOINT."
+            )
+        if self.requires_api_key and not self.config.api_key:
+            return (
+                f"The configured '{self.provider_name}' web-search provider is "
+                "missing its API key. Set "
+                f"{self.api_key_environment} or WEB_SEARCH_API_KEY."
+            )
+        return None
+
     def search(self, *, query: str, limit: int | None = None) -> WebSearchResponse:
-        """Search Brave and return normalized results.
-
-        Args:
-            query: Search query text.
-            limit: Optional per-call result cap. The effective value is clamped
-                to the configured maximum.
-
-        Returns:
-            ``WebSearchResponse`` containing results, no-result status, or a
-            graceful unavailable error.
-        """
+        """Search the provider using common validation and failure handling."""
         clean_query = str(query or "").strip()
         effective_limit = _effective_limit(limit, self.config.max_results)
         if not clean_query:
             return WebSearchResponse(
                 query=clean_query,
-                provider=self.config.provider,
+                provider=self.provider_name,
                 results=[],
                 error="Search query is empty.",
             )
-        if not self.config.api_key:
+
+        configuration_error = self.configuration_error()
+        if configuration_error:
             return WebSearchResponse(
                 query=clean_query,
-                provider=self.config.provider,
+                provider=self.provider_name,
                 results=[],
-                error="BRAVE_SEARCH_API_KEY or WEB_SEARCH_API_KEY is not configured.",
+                error=configuration_error,
             )
 
         logger.info(
             "web_search_request",
             extra={
-                "provider": self.config.provider,
+                "provider": self.provider_name,
                 "query": clean_query,
                 "limit": effective_limit,
             },
@@ -164,47 +192,35 @@ class BraveSearchProvider:
             logger.warning(
                 "web_search_failed",
                 extra={
-                    "provider": self.config.provider,
+                    "provider": self.provider_name,
                     "query": clean_query,
                     "error": response.error,
                 },
             )
-            return response
-        logger.info(
-            "web_search_response",
-            extra={
-                "provider": self.config.provider,
-                "query": clean_query,
-                "result_count": len(response.results),
-            },
-        )
+        else:
+            logger.info(
+                "web_search_response",
+                extra={
+                    "provider": self.provider_name,
+                    "query": clean_query,
+                    "result_count": len(response.results),
+                },
+            )
         return response
 
     def _request_with_retries(self, query: str, limit: int) -> WebSearchResponse:
-        """Execute one Brave request with bounded retry/backoff."""
+        """Execute one provider request with configured retry and backoff limits."""
         last_error = "Search provider failed."
         attempts = max(0, self.config.max_retries) + 1
         for attempt in range(attempts):
             try:
                 with self.client_factory(timeout=self.config.timeout_seconds) as client:
-                    response = client.get(
-                        self.config.endpoint,
-                        headers={
-                            "Accept": "application/json",
-                            "X-Subscription-Token": self.config.api_key or "",
-                        },
-                        params={
-                            "q": query,
-                            "count": limit,
-                            "text_decorations": "false",
-                        },
-                    )
-                    response.raise_for_status()
-                    return WebSearchResponse(
-                        query=query,
-                        provider=self.config.provider,
-                        results=_parse_brave_results(response.json(), limit),
-                    )
+                    results = self._perform_search(client, query, limit)
+                return WebSearchResponse(
+                    query=query,
+                    provider=self.provider_name,
+                    results=results[:limit],
+                )
             except httpx.TimeoutException as exc:
                 last_error = f"Search request timed out: {exc}"
             except httpx.HTTPStatusError as exc:
@@ -220,9 +236,296 @@ class BraveSearchProvider:
 
         return WebSearchResponse(
             query=query,
-            provider=self.config.provider,
+            provider=self.provider_name,
             results=[],
             error=last_error,
+        )
+
+    def _perform_search(
+        self,
+        client: httpx.Client,
+        query: str,
+        limit: int,
+    ) -> list[WebSearchResult]:
+        """Execute and normalize one provider request."""
+        raise NotImplementedError
+
+
+class BraveSearchAdapter(BaseWebSearchAdapter):
+    """Adapt the Brave Search API to FurnaceMind's normalized contract."""
+
+    provider_name = "brave"
+    api_key_environment = "BRAVE_SEARCH_API_KEY"
+    endpoint_environment = "BRAVE_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.get(
+            self.config.endpoint,
+            headers={
+                "Accept": "application/json",
+                "X-Subscription-Token": self.config.api_key or "",
+            },
+            params={"q": query, "count": limit, "text_decorations": "false"},
+        )
+        response.raise_for_status()
+        return _parse_brave_results(response.json(), limit)
+
+
+class TavilySearchAdapter(BaseWebSearchAdapter):
+    """Adapt Tavily's search endpoint to FurnaceMind search results."""
+
+    provider_name = "tavily"
+    api_key_environment = "TAVILY_API_KEY"
+    endpoint_environment = "TAVILY_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.post(
+            self.config.endpoint,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.config.api_key or ''}",
+                "Content-Type": "application/json",
+            },
+            json={"query": query, "max_results": limit},
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            response.json().get("results") or [],
+            limit,
+            title_keys=("title",),
+            url_keys=("url",),
+            snippet_keys=("content", "snippet", "raw_content"),
+        )
+
+
+class ExaSearchAdapter(BaseWebSearchAdapter):
+    """Adapt Exa search and highlight content to normalized results."""
+
+    provider_name = "exa"
+    api_key_environment = "EXA_API_KEY"
+    endpoint_environment = "EXA_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.post(
+            self.config.endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "x-api-key": self.config.api_key or "",
+            },
+            json={
+                "query": query,
+                "numResults": limit,
+                "contents": {"highlights": True},
+            },
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            response.json().get("results") or [],
+            limit,
+            title_keys=("title",),
+            url_keys=("url",),
+            snippet_keys=("summary", "highlights", "text"),
+        )
+
+
+class ParallelSearchAdapter(BaseWebSearchAdapter):
+    """Adapt Parallel Search API excerpts to normalized search results."""
+
+    provider_name = "parallel"
+    api_key_environment = "PARALLEL_API_KEY"
+    endpoint_environment = "PARALLEL_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.post(
+            self.config.endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "x-api-key": self.config.api_key or "",
+            },
+            json={"objective": query, "search_queries": [query]},
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            response.json().get("results") or [],
+            limit,
+            title_keys=("title", "name"),
+            url_keys=("url", "link"),
+            snippet_keys=("excerpts", "snippet", "content"),
+        )
+
+
+class FirecrawlSearchAdapter(BaseWebSearchAdapter):
+    """Adapt Firecrawl's web-search response without using its scrape flow."""
+
+    provider_name = "firecrawl"
+    api_key_environment = "FIRECRAWL_API_KEY"
+    endpoint_environment = "FIRECRAWL_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.post(
+            self.config.endpoint,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.config.api_key or ''}",
+                "Content-Type": "application/json",
+            },
+            json={"query": query, "limit": limit, "sources": ["web"]},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data") or {}
+        rows = data.get("web") if isinstance(data, dict) else data
+        return _normalize_result_rows(
+            rows or [],
+            limit,
+            title_keys=("title",),
+            url_keys=("url",),
+            snippet_keys=("description", "snippet", "markdown"),
+        )
+
+
+class SerperSearchAdapter(BaseWebSearchAdapter):
+    """Adapt Serper's Google organic search results to the common contract."""
+
+    provider_name = "serper"
+    api_key_environment = "SERPER_API_KEY"
+    endpoint_environment = "SERPER_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.post(
+            self.config.endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "X-API-KEY": self.config.api_key or "",
+            },
+            json={"q": query, "num": limit},
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            response.json().get("organic") or [],
+            limit,
+            title_keys=("title",),
+            url_keys=("link", "url"),
+            snippet_keys=("snippet", "description"),
+        )
+
+
+class DuckDuckGoSearchAdapter(BaseWebSearchAdapter):
+    """Parse DuckDuckGo's public HTML results without requiring an API key.
+
+    DuckDuckGo does not expose a supported full web-results JSON API. This
+    adapter therefore targets the lightweight HTML endpoint and may require
+    maintenance if that page structure changes.
+    """
+
+    provider_name = "duckduckgo"
+    requires_api_key = False
+    endpoint_environment = "DUCKDUCKGO_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.get(
+            self.config.endpoint,
+            headers={
+                "Accept": "text/html,application/xhtml+xml",
+                "User-Agent": "FurnaceMind/1.0 web-search",
+            },
+            params={"q": query},
+        )
+        response.raise_for_status()
+        parser = _DuckDuckGoHTMLResultParser()
+        parser.feed(response.text)
+        return parser.results[:limit]
+
+
+class SearXNGSearchAdapter(BaseWebSearchAdapter):
+    """Adapt a configured self-hosted SearXNG JSON search endpoint."""
+
+    provider_name = "searxng"
+    requires_api_key = False
+    endpoint_environment = "SEARXNG_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.get(
+            _endpoint_with_default_path(self.config.endpoint, "/search"),
+            headers=_optional_bearer_headers(self.config.api_key),
+            params={"q": query, "format": "json"},
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            response.json().get("results") or [],
+            limit,
+            title_keys=("title",),
+            url_keys=("url",),
+            snippet_keys=("content", "snippet"),
+        )
+
+
+class WhoogleSearchAdapter(BaseWebSearchAdapter):
+    """Adapt a configured self-hosted Whoogle JSON search endpoint."""
+
+    provider_name = "whoogle"
+    requires_api_key = False
+    endpoint_environment = "WHOOGLE_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.get(
+            _endpoint_with_default_path(self.config.endpoint, "/search"),
+            headers=_optional_bearer_headers(self.config.api_key),
+            params={"q": query, "format": "json"},
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            response.json().get("results") or [],
+            limit,
+            title_keys=("text", "title"),
+            url_keys=("href", "url"),
+            snippet_keys=("description", "snippet"),
+        )
+
+
+class YaCySearchAdapter(BaseWebSearchAdapter):
+    """Adapt a configured self-hosted YaCy JSON search endpoint."""
+
+    provider_name = "yacy"
+    requires_api_key = False
+    endpoint_environment = "YACY_SEARCH_ENDPOINT"
+
+    def _perform_search(
+        self, client: httpx.Client, query: str, limit: int
+    ) -> list[WebSearchResult]:
+        response = client.get(
+            _endpoint_with_default_path(self.config.endpoint, "/yacysearch.json"),
+            headers=_optional_bearer_headers(self.config.api_key),
+            params={"query": query, "maximumRecords": limit},
+        )
+        response.raise_for_status()
+        return _normalize_result_rows(
+            _extract_yacy_rows(response.json()),
+            limit,
+            title_keys=("title",),
+            url_keys=("link", "url"),
+            snippet_keys=("description", "snippet"),
         )
 
 
@@ -236,18 +539,37 @@ def _effective_limit(limit: int | None, configured_limit: int) -> int:
 
 
 def _clean_text(value: Any) -> str:
-    """Convert provider text fields into single-line strings."""
+    """Convert provider text fields, including lists, into one clean line."""
+    if isinstance(value, (list, tuple, set)):
+        value = " ".join(_clean_text(item) for item in value if item is not None)
     return " ".join(str(value or "").split())
 
 
-def _parse_brave_results(payload: dict[str, Any], limit: int) -> list[WebSearchResult]:
-    """Normalize Brave Search JSON into FurnaceMind search results."""
-    raw_results = (payload.get("web") or {}).get("results") or []
+def _first_row_value(row: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty normalized value from candidate payload keys."""
+    for key in keys:
+        value = _clean_text(row.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _normalize_result_rows(
+    rows: list[dict[str, Any]],
+    limit: int,
+    *,
+    title_keys: tuple[str, ...],
+    url_keys: tuple[str, ...],
+    snippet_keys: tuple[str, ...],
+) -> list[WebSearchResult]:
+    """Normalize provider rows using ordered candidate field names."""
     results: list[WebSearchResult] = []
-    for raw in raw_results:
-        title = _clean_text(raw.get("title"))
-        url = _clean_text(raw.get("url"))
-        snippet = _clean_text(raw.get("description") or raw.get("snippet"))
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        title = _first_row_value(row, title_keys)
+        url = _first_row_value(row, url_keys)
+        snippet = _first_row_value(row, snippet_keys)
         if not title or not url:
             continue
         results.append(WebSearchResult(title=title, url=url, snippet=snippet))
@@ -256,22 +578,171 @@ def _parse_brave_results(payload: dict[str, Any], limit: int) -> list[WebSearchR
     return results
 
 
+def _parse_brave_results(payload: dict[str, Any], limit: int) -> list[WebSearchResult]:
+    """Normalize Brave Search JSON into FurnaceMind search results."""
+    return _normalize_result_rows(
+        (payload.get("web") or {}).get("results") or [],
+        limit,
+        title_keys=("title",),
+        url_keys=("url",),
+        snippet_keys=("description", "snippet"),
+    )
+
+
+def _optional_bearer_headers(api_key: str | None) -> dict[str, str]:
+    """Build JSON headers and add optional auth for protected self-hosted APIs."""
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _endpoint_with_default_path(endpoint: str, default_path: str) -> str:
+    """Append an API path when a self-hosted endpoint only contains its origin."""
+    parsed = urlsplit(str(endpoint or "").strip())
+    if parsed.path not in ("", "/"):
+        return endpoint
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, default_path, parsed.query, parsed.fragment)
+    )
+
+
+def _extract_yacy_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract YaCy's RSS-like result rows across supported JSON layouts."""
+    direct_items = payload.get("items")
+    if isinstance(direct_items, list):
+        return direct_items
+
+    channel = payload.get("channel")
+    if isinstance(channel, dict) and isinstance(channel.get("items"), list):
+        return channel["items"]
+
+    rows: list[dict[str, Any]] = []
+    for item in payload.get("channels") or []:
+        if isinstance(item, dict) and isinstance(item.get("items"), list):
+            rows.extend(item["items"])
+    return rows
+
+
+def _normalize_duckduckgo_url(url: str) -> str:
+    """Resolve DuckDuckGo redirect links to their external destination URL."""
+    candidate = str(url or "").strip()
+    if candidate.startswith("//"):
+        candidate = f"https:{candidate}"
+    parsed = urlsplit(candidate)
+    redirected = parse_qs(parsed.query).get("uddg")
+    if redirected:
+        return unquote(redirected[0])
+    return candidate
+
+
+class _DuckDuckGoHTMLResultParser(HTMLParser):
+    """Extract result titles, links, and snippets from DuckDuckGo HTML output."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.results: list[WebSearchResult] = []
+        self._capture: str | None = None
+        self._capture_tag: str | None = None
+        self._buffer: list[str] = []
+        self._result_url = ""
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Start capturing recognized result title or snippet elements."""
+        attributes = dict(attrs)
+        classes = set(str(attributes.get("class") or "").split())
+        if tag == "a" and "result__a" in classes:
+            self._capture = "title"
+            self._capture_tag = tag
+            self._buffer = []
+            self._result_url = _normalize_duckduckgo_url(
+                str(attributes.get("href") or "")
+            )
+        elif "result__snippet" in classes:
+            self._capture = "snippet"
+            self._capture_tag = tag
+            self._buffer = []
+
+    def handle_data(self, data: str) -> None:
+        """Collect visible text while inside a recognized result element."""
+        if self._capture:
+            self._buffer.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        """Finish the active result field when its containing element closes."""
+        if not self._capture or tag != self._capture_tag:
+            return
+        value = _clean_text(" ".join(self._buffer))
+        if self._capture == "title" and value and self._result_url:
+            self.results.append(
+                WebSearchResult(title=value, url=self._result_url, snippet="")
+            )
+        elif self._capture == "snippet" and value and self.results:
+            previous = self.results[-1]
+            self.results[-1] = WebSearchResult(
+                title=previous.title,
+                url=previous.url,
+                snippet=value,
+            )
+        self._capture = None
+        self._capture_tag = None
+        self._buffer = []
+
+
+_WEB_SEARCH_PROVIDER_FACTORIES: dict[str, WebSearchProviderFactory] = {
+    BraveSearchAdapter.provider_name: BraveSearchAdapter,
+    TavilySearchAdapter.provider_name: TavilySearchAdapter,
+    ExaSearchAdapter.provider_name: ExaSearchAdapter,
+    ParallelSearchAdapter.provider_name: ParallelSearchAdapter,
+    FirecrawlSearchAdapter.provider_name: FirecrawlSearchAdapter,
+    SerperSearchAdapter.provider_name: SerperSearchAdapter,
+    DuckDuckGoSearchAdapter.provider_name: DuckDuckGoSearchAdapter,
+    SearXNGSearchAdapter.provider_name: SearXNGSearchAdapter,
+    WhoogleSearchAdapter.provider_name: WhoogleSearchAdapter,
+    YaCySearchAdapter.provider_name: YaCySearchAdapter,
+}
+
+
+def register_web_search_provider(
+    provider_name: str,
+    factory: WebSearchProviderFactory,
+) -> None:
+    """Register or replace an adapter factory under a normalized provider name."""
+    normalized_name = normalize_web_search_provider_name(provider_name)
+    if not normalized_name:
+        raise ValueError("Web-search provider name cannot be empty.")
+    _WEB_SEARCH_PROVIDER_FACTORIES[normalized_name] = factory
+
+
 def build_web_search_provider(
     config: WebSearchConfig | None = None,
-) -> BraveSearchProvider:
-    """Build the configured web search provider.
-
-    Raises:
-        ValueError: If ``WEB_SEARCH_PROVIDER`` names an unsupported provider.
-    """
+) -> WebSearchProvider:
+    """Build the configured adapter or reject an unsupported provider name."""
     cfg = config or settings.web_search
-    if cfg.provider != "brave":
-        raise ValueError(f"Unsupported WEB_SEARCH_PROVIDER: {cfg.provider}")
-    return BraveSearchProvider(cfg)
+    provider_name = normalize_web_search_provider_name(cfg.provider)
+    factory = _WEB_SEARCH_PROVIDER_FACTORIES.get(provider_name)
+    if factory is None:
+        supported = ", ".join(sorted(_WEB_SEARCH_PROVIDER_FACTORIES))
+        raise ValueError(
+            f"Unsupported WEB_SEARCH_PROVIDER: {cfg.provider}. "
+            f"Supported providers: {supported}."
+        )
+    return factory(cfg)
+
+
+def web_search_configuration_error(
+    config: WebSearchConfig | None = None,
+) -> str | None:
+    """Return why the configured search adapter cannot run, if applicable."""
+    try:
+        provider = build_web_search_provider(config)
+    except Exception as exc:
+        return f"Web search is unavailable: {exc}"
+    return provider.configuration_error()
 
 
 def search_web(query: str, *, limit: int | None = None) -> str:
-    """Run web search through the configured provider and render tool output."""
+    """Run the configured provider and render normalized tool output."""
     try:
         provider = build_web_search_provider()
         response = provider.search(query=query, limit=limit)
@@ -292,3 +763,7 @@ def search_web(query: str, *, limit: int | None = None) -> str:
             },
         )
     return response.to_tool_text()
+
+
+# Preserve the original public class name used by older imports.
+BraveSearchProvider = BraveSearchAdapter

--- a/src/agents/multimodal/ingestion.py
+++ b/src/agents/multimodal/ingestion.py
@@ -182,8 +182,6 @@ def _read_upload_bytes(file) -> bytes:
     return data
 
 
-
-
 def _document_id(file_bytes: bytes) -> str:
     """Create the stable MRAG document id for an upload.
 
@@ -324,6 +322,7 @@ def _text_parts(
     slide_number: int | None = None,
     sheet_name: str | None = None,
     user_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> tuple[list[DocumentPart], int]:
     """Convert extracted text into ordered ``DocumentPart`` objects.
 
@@ -339,15 +338,18 @@ def _text_parts(
         slide_number: Source PPTX slide number, if any.
         sheet_name: Source Excel sheet name, if any.
         user_id: Optional owner id for user-scoped retrieval.
+        metadata: Shared payload metadata copied to every text chunk.
 
     Returns:
         Tuple of ``(parts, next_chunk_index)``. ``parts`` may be empty when the
         text is blank.
     """
+    base_metadata = {**(metadata or {})}
     parts: list[DocumentPart] = []
     chunk_index = chunk_index_start
     for text_index, chunk in enumerate(chunk_text(text), start=1):
         chunk_id = f"{modality}_{chunk_index:04d}"
+        metadata_payload = {**base_metadata, "text_chunk_index": text_index}
         parts.append(
             DocumentPart(
                 document_id=document_id,
@@ -361,7 +363,7 @@ def _text_parts(
                 page_number=page_number,
                 slide_number=slide_number,
                 sheet_name=sheet_name,
-                metadata={"text_chunk_index": text_index},
+                metadata=metadata_payload,
             )
         )
         chunk_index += 1
@@ -435,6 +437,7 @@ def build_document_parts(
     file_bytes: bytes,
     *,
     user_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> list[DocumentPart]:
     """Parse an upload and normalize it into MRAG parts.
 
@@ -445,6 +448,8 @@ def build_document_parts(
         filename: Original uploaded filename. The extension selects the parser.
         file_bytes: Raw uploaded file bytes.
         user_id: Optional owner id copied into every generated part.
+        metadata: Optional shared payload metadata copied into every part, used
+            by external knowledge ingestion for URL/title/source attribution.
 
     Returns:
         Ordered list of ``DocumentPart`` objects. The list may contain both text
@@ -464,6 +469,7 @@ def build_document_parts(
     document_id = _document_id(file_bytes)
     parts: list[DocumentPart] = []
     chunk_index = 0
+    base_metadata = {**(metadata or {})}
 
     if file_type in {"png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff"}:
         parts.append(
@@ -480,6 +486,7 @@ def build_document_parts(
                     "visual evidence, OCR, diagrams, labels, and layout."
                 ),
                 suffix=_image_suffix(file_bytes, file_type if file_type else "png"),
+                metadata=base_metadata,
             )
         )
         return parts
@@ -497,6 +504,7 @@ def build_document_parts(
                 chunk_index_start=chunk_index,
                 page_number=page_number,
                 user_id=user_id,
+                metadata=base_metadata,
             )
             parts.extend(text_parts)
             image_bytes = page.get("image_bytes")
@@ -516,6 +524,7 @@ def build_document_parts(
                             "page image for scanned text, visual tables, charts, "
                             "diagrams, labels, and layout."
                         ),
+                        metadata=base_metadata,
                     )
                 )
                 chunk_index += 1
@@ -530,6 +539,7 @@ def build_document_parts(
             text=extract_docx_text(file_bytes),
             chunk_index_start=chunk_index,
             user_id=user_id,
+            metadata=base_metadata,
         )
         return text_parts
 
@@ -550,6 +560,7 @@ def build_document_parts(
                 chunk_index_start=chunk_index,
                 slide_number=slide_number,
                 user_id=user_id,
+                metadata=base_metadata,
             )
             parts.extend(text_parts)
             rendered_image = rendered_slide_images.get(slide_number)
@@ -570,7 +581,7 @@ def build_document_parts(
                             "tables, diagrams, and other visual evidence."
                         ),
                         suffix="png",
-                        metadata={"render_source": "libreoffice"},
+                        metadata={**base_metadata, "render_source": "libreoffice"},
                     )
                 )
                 chunk_index += 1
@@ -592,7 +603,10 @@ def build_document_parts(
                             "Use this image for visual evidence from the presentation."
                         ),
                         suffix=_image_suffix(image_blob),
-                        metadata={"slide_image_index": slide_image_index},
+                        metadata={
+                            **base_metadata,
+                            "slide_image_index": slide_image_index,
+                        },
                     )
                 )
                 chunk_index += 1
@@ -609,6 +623,7 @@ def build_document_parts(
                 chunk_index_start=chunk_index,
                 sheet_name=str(sheet.get("sheet_name") or ""),
                 user_id=user_id,
+                metadata=base_metadata,
             )
             parts.extend(text_parts)
         return parts
@@ -622,6 +637,7 @@ def build_document_parts(
             text=extract_csv_text(file_bytes),
             chunk_index_start=chunk_index,
             user_id=user_id,
+            metadata=base_metadata,
         )
         return text_parts
 
@@ -634,6 +650,7 @@ def build_document_parts(
             text=extract_text_file(file_bytes),
             chunk_index_start=chunk_index,
             user_id=user_id,
+            metadata=base_metadata,
         )
         return text_parts
 
@@ -685,7 +702,8 @@ def _document_metadata(parts: list[DocumentPart]) -> dict[str, Any]:
         count. This supports the sidebar document library and delete cleanup
         without storing local filesystem paths.
     """
-    return {
+    first_metadata = parts[0].metadata if isinstance(parts[0].metadata, dict) else {}
+    payload = {
         "source": "furnacemind_knowledge",
         "document_id": parts[0].document_id,
         "user_id": parts[0].user_id or "",
@@ -703,6 +721,18 @@ def _document_metadata(parts: list[DocumentPart]) -> dict[str, Any]:
             [part for part in parts if part.image_bytes is not None or part.image_path]
         ),
     }
+    for key in (
+        "source_type",
+        "source_url",
+        "title",
+        "web_title",
+        "provider",
+        "fetched_at",
+        "sha256",
+    ):
+        if first_metadata.get(key) not in (None, ""):
+            payload[key] = first_metadata[key]
+    return payload
 
 
 def _persist_document_metadata(
@@ -826,6 +856,7 @@ def process_file(
     user_id: str | None = None,
     document_repository: Any | None = None,
     chunk_repository: Any | None = None,
+    source_metadata: dict[str, Any] | None = None,
 ) -> list[DocumentPart]:
     """Index one uploaded file into the multimodal knowledge collection.
 
@@ -844,6 +875,8 @@ def process_file(
         user_id: Optional owner id copied to Qdrant payloads and SQL metadata.
         document_repository: Optional SQL repository for document-level metadata.
         chunk_repository: Optional SQL repository for chunk-level metadata.
+        source_metadata: Optional metadata copied into Qdrant payloads and SQL
+            document metadata, used for externally scraped knowledge sources.
 
     Returns:
         List of ``DocumentPart`` objects that were embedded and upserted. Empty
@@ -858,7 +891,12 @@ def process_file(
     filename = getattr(file, "name", "upload")
     content_type = getattr(file, "type", None)
     file_bytes = _read_upload_bytes(file)
-    parts = build_document_parts(filename, file_bytes, user_id=user_id)
+    parts = build_document_parts(
+        filename,
+        file_bytes,
+        user_id=user_id,
+        metadata=source_metadata,
+    )
     if not parts:
         return []
 

--- a/src/ui/furnacemind/chat_interface.py
+++ b/src/ui/furnacemind/chat_interface.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import streamlit as st
 
+from agents.furnacemind.web_ingestion import ingest_external_knowledge_url
 from agents.multimodal.ingestion import process_file
 from utils.furnacemind.skill_ui import (
     build_skill_context_preview,
@@ -33,6 +34,7 @@ from utils.furnacemind.skill_ui import (
     store_skill_markdown,
     unique_skill_slug,
 )
+from utils.settings import settings
 
 if TYPE_CHECKING:
     from agents.furnacemind.skill_registry import SkillDefinition, SkillRegistry
@@ -1072,6 +1074,9 @@ def render_knowledge_sidebar(
         st.caption("PDF, images, PPTX, Excel, CSV, DOCX, TXT, and Markdown")
         upload_message = st.session_state.pop("fm_knowledge_upload_result", None)
         remove_message = st.session_state.pop("fm_knowledge_remove_result", None)
+        web_source_message = st.session_state.pop(
+            "fm_knowledge_web_source_result", None
+        )
         memory_warning = st.session_state.pop(
             "fm_knowledge_memory_cleanup_warning", None
         )
@@ -1079,6 +1084,8 @@ def render_knowledge_sidebar(
             st.success(upload_message)
         if remove_message:
             st.success(remove_message)
+        if web_source_message:
+            st.success(web_source_message)
         if memory_warning:
             st.warning(memory_warning)
 
@@ -1133,12 +1140,93 @@ def render_knowledge_sidebar(
                 upload_status.warning(
                     f"Skipped unsupported or empty files: {', '.join(skipped_files)}"
                 )
+        _render_web_source_ingestion(
+            knowledge_store=knowledge_store,
+            embedding_client=embedding_client,
+            user_id=user_id,
+            document_repository=document_repository,
+            chunk_repository=chunk_repository,
+        )
         _render_knowledge_documents(
             knowledge_store=knowledge_store,
             user_id=user_id,
             document_repository=document_repository,
             semantic_memory_service=semantic_memory_service,
         )
+
+
+def _render_web_source_ingestion(
+    *,
+    knowledge_store: Any,
+    embedding_client: Any,
+    user_id: str | None,
+    document_repository: Any | None,
+    chunk_repository: Any | None,
+) -> None:
+    """Render URL-based external knowledge ingestion controls.
+
+    This control is the UI equivalent of the ``web_scrape_ingest`` tool. It
+    scrapes a user-provided URL through the configured reader provider, stores
+    the scraped Markdown bytes on the SQL ``memory_documents`` row, and indexes
+    the resulting chunks into the shared FurnaceMind knowledge vector store.
+    The control is deliberately disabled unless URL ingestion is explicitly
+    enabled and SQL document persistence is available.
+    """
+    st.caption("Add web source")
+    ingestion_enabled = bool(settings.web_scrape.ingest_enabled)
+    persistence_ready = bool(user_id and document_repository is not None)
+    disabled_reason = ""
+    if not ingestion_enabled:
+        disabled_reason = "Set WEB_SCRAPE_INGEST_ENABLED=true to enable URL ingestion."
+    elif not persistence_ready:
+        disabled_reason = "SQL document storage is unavailable for web sources."
+
+    with st.form("fm_web_source_ingest_form", clear_on_submit=True):
+        source_url = st.text_input(
+            "Source URL",
+            placeholder="https://example.com/blast-furnace-reference",
+            help="Scrape this public page and add it to shared FurnaceMind knowledge.",
+        )
+        submitted = st.form_submit_button(
+            "Scrape & Index URL",
+            use_container_width=True,
+            disabled=bool(disabled_reason),
+        )
+
+    if disabled_reason:
+        st.caption(disabled_reason)
+        return
+    if not submitted:
+        return
+
+    clean_url = str(source_url or "").strip()
+    if not clean_url:
+        st.warning("Paste a URL before indexing.")
+        return
+
+    with st.spinner("Scraping and indexing web source..."):
+        result = ingest_external_knowledge_url(
+            clean_url,
+            knowledge_store=knowledge_store,
+            embedding_client=embedding_client,
+            user_id=user_id,
+            document_repository=document_repository,
+            chunk_repository=chunk_repository,
+        )
+
+    if result.status == "indexed":
+        st.session_state["fm_knowledge_web_source_result"] = (
+            f"Indexed web source {result.filename or result.url}, "
+            f"{result.chunk_count} searchable part(s)."
+        )
+        st.rerun()
+    if result.status == "already_indexed":
+        st.session_state["fm_knowledge_web_source_result"] = (
+            f"Web source already indexed: {result.filename or result.url}."
+        )
+        st.rerun()
+
+    st.warning(result.error or f"Web source ingestion returned status: {result.status}")
 
 
 def _document_metadata(document: Any) -> dict[str, Any]:

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -246,19 +246,103 @@ class SemanticMemoryConfig:
 # ==========================================================
 
 
+_WEB_SEARCH_PROVIDER_ALIASES = {
+    "ddg": "duckduckgo",
+    "duck-duck-go": "duckduckgo",
+    "duck_duck_go": "duckduckgo",
+    "fire_crawl": "firecrawl",
+    "searx": "searxng",
+    "serpent": "serper",
+    "whoogle-search": "whoogle",
+    "whoogle_search": "whoogle",
+}
+
+_WEB_SEARCH_PROVIDER_CONFIG = {
+    "brave": {
+        "endpoint": "https://api.search.brave.com/res/v1/web/search",
+        "endpoint_envs": ("BRAVE_SEARCH_ENDPOINT",),
+        "api_key_envs": ("BRAVE_SEARCH_API_KEY",),
+    },
+    "tavily": {
+        "endpoint": "https://api.tavily.com/search",
+        "endpoint_envs": ("TAVILY_SEARCH_ENDPOINT", "TAVILY_ENDPOINT"),
+        "api_key_envs": ("TAVILY_API_KEY", "TAVILY_SEARCH_API_KEY"),
+    },
+    "exa": {
+        "endpoint": "https://api.exa.ai/search",
+        "endpoint_envs": ("EXA_SEARCH_ENDPOINT", "EXA_ENDPOINT"),
+        "api_key_envs": ("EXA_API_KEY", "EXA_SEARCH_API_KEY"),
+    },
+    "parallel": {
+        "endpoint": "https://api.parallel.ai/v1/search",
+        "endpoint_envs": ("PARALLEL_SEARCH_ENDPOINT", "PARALLEL_ENDPOINT"),
+        "api_key_envs": ("PARALLEL_API_KEY", "PARALLEL_SEARCH_API_KEY"),
+    },
+    "firecrawl": {
+        "endpoint": "https://api.firecrawl.dev/v2/search",
+        "endpoint_envs": ("FIRECRAWL_SEARCH_ENDPOINT", "FIRECRAWL_ENDPOINT"),
+        "api_key_envs": ("FIRECRAWL_API_KEY",),
+    },
+    "serper": {
+        "endpoint": "https://google.serper.dev/search",
+        "endpoint_envs": ("SERPER_SEARCH_ENDPOINT", "SERPER_ENDPOINT"),
+        "api_key_envs": ("SERPER_API_KEY",),
+    },
+    "duckduckgo": {
+        "endpoint": "https://html.duckduckgo.com/html/",
+        "endpoint_envs": ("DUCKDUCKGO_SEARCH_ENDPOINT", "DUCKDUCKGO_ENDPOINT"),
+        "api_key_envs": (),
+    },
+    "searxng": {
+        "endpoint": "",
+        "endpoint_envs": ("SEARXNG_SEARCH_ENDPOINT", "SEARXNG_ENDPOINT"),
+        "api_key_envs": ("SEARXNG_API_KEY",),
+    },
+    "whoogle": {
+        "endpoint": "",
+        "endpoint_envs": ("WHOOGLE_SEARCH_ENDPOINT", "WHOOGLE_ENDPOINT"),
+        "api_key_envs": ("WHOOGLE_API_KEY",),
+    },
+    "yacy": {
+        "endpoint": "",
+        "endpoint_envs": ("YACY_SEARCH_ENDPOINT", "YACY_ENDPOINT"),
+        "api_key_envs": ("YACY_API_KEY",),
+    },
+}
+
+
+def normalize_web_search_provider_name(provider: str | None) -> str:
+    """Return the canonical registry name for a configured search provider."""
+    normalized = str(provider or "").strip().lower()
+    return _WEB_SEARCH_PROVIDER_ALIASES.get(normalized, normalized)
+
+
+def _first_configured_environment_value(names: tuple[str, ...]) -> str | None:
+    """Return the first non-empty value from an ordered env-var list."""
+    for name in names:
+        value = os.getenv(name)
+        if value is not None and value.strip():
+            return value.strip()
+    return None
+
+
 @dataclass(frozen=True)
 class WebSearchConfig:
     """Configuration for the provider-neutral FurnaceMind web search tool.
 
     Attributes:
-        provider: Search provider name. The first implementation supports
-            ``"brave"``.
-        api_key: Provider API key. For Brave this comes from
-            ``BRAVE_SEARCH_API_KEY`` or ``WEB_SEARCH_API_KEY``.
-        endpoint: Provider web-search endpoint.
+        provider: Canonical search provider name. Supported adapters are Brave,
+            Tavily, Exa, Parallel, Firecrawl, Serper, DuckDuckGo, SearXNG,
+            Whoogle, and YaCy.
+        api_key: Provider API key. The generic ``WEB_SEARCH_API_KEY`` is
+            supported along with provider-specific environment variables.
+        endpoint: Provider web-search endpoint. Hosted providers have defaults;
+            self-hosted SearXNG, Whoogle, and YaCy deployments must configure it.
         max_results: Maximum results returned to the model per search.
         timeout_seconds: HTTP timeout for one provider request.
         max_retries: Number of retry attempts after the initial request fails.
+        max_requests_per_session: Maximum logical searches allowed in one
+            Streamlit browser session.
     """
 
     provider: str = "brave"
@@ -267,6 +351,7 @@ class WebSearchConfig:
     max_results: int = 5
     timeout_seconds: float = 10.0
     max_retries: int = 2
+    max_requests_per_session: int = 5
 
 
 @dataclass(frozen=True)
@@ -607,22 +692,34 @@ class Settings:
     def _load_web_search_config() -> WebSearchConfig:
         """Build web-search settings from environment variables.
 
-        Missing API keys are allowed because web search is an optional tool. The
-        tool itself returns a graceful unavailable message when called without a
-        configured provider key.
+        Provider-specific credentials and endpoints take precedence over the
+        generic ``WEB_SEARCH_API_KEY`` and ``WEB_SEARCH_ENDPOINT`` values. A
+        missing key or self-hosted endpoint is allowed at startup because web
+        search is optional; the selected adapter reports a graceful unavailable
+        message if the user later enables it.
         """
-        provider = os.getenv("WEB_SEARCH_PROVIDER", "brave").strip().lower() or "brave"
-        endpoint = os.getenv(
-            "BRAVE_SEARCH_ENDPOINT",
-            os.getenv(
-                "WEB_SEARCH_ENDPOINT",
-                "https://api.search.brave.com/res/v1/web/search",
-            ),
+        configured_provider = os.getenv("WEB_SEARCH_PROVIDER", "brave")
+        provider = normalize_web_search_provider_name(configured_provider) or "brave"
+        generic_endpoint = os.getenv("WEB_SEARCH_ENDPOINT", "").strip()
+        generic_api_key = (os.getenv("WEB_SEARCH_API_KEY") or "").strip() or None
+        provider_config = _WEB_SEARCH_PROVIDER_CONFIG.get(provider, {})
+        endpoint = (
+            _first_configured_environment_value(
+                provider_config.get("endpoint_envs", ())
+            )
+            or generic_endpoint
+            or str(provider_config.get("endpoint", ""))
         ).strip()
-        api_key = os.getenv("BRAVE_SEARCH_API_KEY") or os.getenv("WEB_SEARCH_API_KEY")
+        api_key = (
+            _first_configured_environment_value(provider_config.get("api_key_envs", ()))
+            or generic_api_key
+        )
         max_results = _parse_int_env("WEB_SEARCH_MAX_RESULTS", 5)
         timeout_seconds = _parse_float_env("WEB_SEARCH_TIMEOUT_SECONDS", 10.0)
         max_retries = _parse_int_env("WEB_SEARCH_MAX_RETRIES", 2)
+        max_requests_per_session = _parse_int_env(
+            "WEB_SEARCH_MAX_REQUESTS_PER_SESSION", 5
+        )
 
         return WebSearchConfig(
             provider=provider,
@@ -631,6 +728,7 @@ class Settings:
             max_results=max(1, min(max_results, 10)),
             timeout_seconds=max(1.0, timeout_seconds),
             max_retries=max(0, max_retries),
+            max_requests_per_session=max(1, max_requests_per_session),
         )
 
     @staticmethod

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -24,7 +24,7 @@ load_dotenv()
 
 
 # ==========================================================
-# 🔹 LLM CONFIGURATION
+#  LLM CONFIGURATION
 # ==========================================================
 
 
@@ -53,6 +53,34 @@ def normalize_openrouter_reasoning_level(value: str | None) -> str:
     normalized = str(value or "").strip().lower()
     return _REASONING_LEVEL_ALIASES.get(normalized, "Medium")
 
+
+def _parse_int_env(name: str, default: int) -> int:
+    """Return an integer environment value, falling back on invalid input."""
+    try:
+        return int(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _parse_float_env(name: str, default: float) -> float:
+    """Return a float environment value, falling back on invalid input."""
+    try:
+        return float(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _parse_bool_env(name: str, default: bool) -> bool:
+    """Return a boolean environment value, falling back on invalid input."""
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return bool(default)
+    normalized = raw_value.strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off"}:
+        return False
+    return bool(default)
 
 
 def _env_first(*names: str) -> str | None:
@@ -120,7 +148,7 @@ class OpenAILLMConfig:
         base_url:   Optional custom base URL (e.g. for Azure OpenAI).
         model_name: Model identifier (e.g. ``gpt-4o-mini``).
         max_tokens: Maximum completion tokens to request.
-        api_mode:   Which API surface to use — ``"responses"`` or
+        api_mode:   Which API surface to use - ``"responses"`` or
                     ``"chat_completions"``.
     """
 
@@ -136,7 +164,7 @@ class LLMSettings:
     """Top-level LLM provider selection and per-provider config.
 
     Attributes:
-        provider:   Active provider — ``"openrouter"`` or ``"openai"``.
+        provider:   Active provider - ``"openrouter"`` or ``"openai"``.
         openrouter: :class:`OpenRouterLLMConfig` for the OpenRouter gateway.
         openai:     :class:`OpenAILLMConfig` for the OpenAI API.
     """
@@ -151,7 +179,7 @@ class LLMSettings:
 
 
 # ==========================================================
-# 🔹 VECTOR DATABASE CONFIG
+#  VECTOR DATABASE CONFIG
 # ==========================================================
 
 
@@ -175,7 +203,7 @@ class QdrantConfig:
 
 
 # ==========================================================
-# 🔹 APPLICATION CONFIG
+#  APPLICATION CONFIG
 # ==========================================================
 
 
@@ -214,8 +242,61 @@ class SemanticMemoryConfig:
 
 
 # ==========================================================
-# 🔹 SETTINGS LOADER
+#  SETTINGS LOADER
 # ==========================================================
+
+
+@dataclass(frozen=True)
+class WebSearchConfig:
+    """Configuration for the provider-neutral FurnaceMind web search tool.
+
+    Attributes:
+        provider: Search provider name. The first implementation supports
+            ``"brave"``.
+        api_key: Provider API key. For Brave this comes from
+            ``BRAVE_SEARCH_API_KEY`` or ``WEB_SEARCH_API_KEY``.
+        endpoint: Provider web-search endpoint.
+        max_results: Maximum results returned to the model per search.
+        timeout_seconds: HTTP timeout for one provider request.
+        max_retries: Number of retry attempts after the initial request fails.
+    """
+
+    provider: str = "brave"
+    api_key: str | None = None
+    endpoint: str = "https://api.search.brave.com/res/v1/web/search"
+    max_results: int = 5
+    timeout_seconds: float = 10.0
+    max_retries: int = 2
+
+
+@dataclass(frozen=True)
+class WebScrapeConfig:
+    """Configuration for approved external-page ingestion.
+
+    Search is a chat-time tool and does not persist anything. Scraping is a
+    separate background/admin ingestion path that intentionally adds approved
+    public pages to the shared FurnaceMind knowledge base. Jina Reader converts
+    public pages into readable Markdown before the existing MRAG chunking and
+    embedding pipeline stores them.
+
+    Attributes:
+        provider: Reader provider name. The first implementation supports
+            ``"jina_reader"``.
+        api_key: Optional Jina Reader API key.
+        endpoint: Jina Reader endpoint used to fetch readable page content.
+        timeout_seconds: HTTP timeout for one reader request.
+        max_retries: Number of retry attempts after the initial request fails.
+        max_chars: Maximum characters retained from one scraped page.
+        ingest_enabled: Whether chat/tool-triggered ingestion is allowed.
+    """
+
+    provider: str = "jina_reader"
+    api_key: str | None = None
+    endpoint: str = "https://r.jina.ai"
+    timeout_seconds: float = 20.0
+    max_retries: int = 2
+    max_chars: int = 200_000
+    ingest_enabled: bool = False
 
 
 class Settings:
@@ -227,9 +308,9 @@ class Settings:
 
     Two Qdrant targets are supported:
 
-    * ``qdrant_shift`` — 384-dim local embeddings, shift summary store.
-    * ``qdrant_knowledge`` — 1024-dim cloud embeddings, Knowledge Hub.
-    * ``qdrant_skills`` — 1024-dim cloud embeddings, skill retrieval index.
+    * ``qdrant_shift`` - 384-dim local embeddings, shift summary store.
+    * ``qdrant_knowledge`` - 1024-dim cloud embeddings, Knowledge Hub.
+    * ``qdrant_skills`` - 1024-dim cloud embeddings, skill retrieval index.
 
     The ``qdrant`` attribute is an alias for ``qdrant_shift`` for backward
     compatibility with existing call-sites.
@@ -243,6 +324,10 @@ class Settings:
         app:               :class:`AppConfig` general runtime settings.
         memory_summary_message_window: Number of chat messages per memory summary.
         memory_summary_token_limit:    Maximum requested memory summary tokens.
+        web_search:                    Provider, timeout, retry, and result-limit
+                                       config for external web search.
+        web_scrape:                    Provider, timeout, retry, and size-limit
+                                       config for external knowledge ingestion.
     """
 
     def __init__(self) -> None:
@@ -298,6 +383,8 @@ class Settings:
             os.getenv("MEMORY_SUMMARY_TOKEN_LIMIT", 2000)
         )
         self.semantic_memory = self._load_semantic_memory_config()
+        self.web_search = self._load_web_search_config()
+        self.web_scrape = self._load_web_scrape_config()
         self._validate()
 
     # ------------------------------------------------------
@@ -516,6 +603,72 @@ class Settings:
             search_threshold=threshold,
         )
 
+    @staticmethod
+    def _load_web_search_config() -> WebSearchConfig:
+        """Build web-search settings from environment variables.
+
+        Missing API keys are allowed because web search is an optional tool. The
+        tool itself returns a graceful unavailable message when called without a
+        configured provider key.
+        """
+        provider = os.getenv("WEB_SEARCH_PROVIDER", "brave").strip().lower() or "brave"
+        endpoint = os.getenv(
+            "BRAVE_SEARCH_ENDPOINT",
+            os.getenv(
+                "WEB_SEARCH_ENDPOINT",
+                "https://api.search.brave.com/res/v1/web/search",
+            ),
+        ).strip()
+        api_key = os.getenv("BRAVE_SEARCH_API_KEY") or os.getenv("WEB_SEARCH_API_KEY")
+        max_results = _parse_int_env("WEB_SEARCH_MAX_RESULTS", 5)
+        timeout_seconds = _parse_float_env("WEB_SEARCH_TIMEOUT_SECONDS", 10.0)
+        max_retries = _parse_int_env("WEB_SEARCH_MAX_RETRIES", 2)
+
+        return WebSearchConfig(
+            provider=provider,
+            api_key=api_key,
+            endpoint=endpoint,
+            max_results=max(1, min(max_results, 10)),
+            timeout_seconds=max(1.0, timeout_seconds),
+            max_retries=max(0, max_retries),
+        )
+
+    @staticmethod
+    def _load_web_scrape_config() -> WebScrapeConfig:
+        """Build external knowledge scrape settings from environment variables.
+
+        Scrape ingestion uses Jina Reader to convert public pages into Markdown
+        before storing them as shared FurnaceMind knowledge. The API key is
+        optional so local testing can still return graceful unavailable messages
+        instead of failing application startup.
+        """
+        provider = (
+            os.getenv("WEB_SCRAPE_PROVIDER", "jina_reader").strip().lower()
+            or "jina_reader"
+        )
+        endpoint = os.getenv(
+            "JINA_READER_ENDPOINT",
+            os.getenv("WEB_SCRAPE_ENDPOINT", "https://r.jina.ai"),
+        ).strip()
+        api_key = (
+            os.getenv("JINA_READER_API_KEY")
+            or os.getenv("JINA_API_KEY")
+            or os.getenv("WEB_SCRAPE_API_KEY")
+        )
+        timeout_seconds = _parse_float_env("WEB_SCRAPE_TIMEOUT_SECONDS", 20.0)
+        max_retries = _parse_int_env("WEB_SCRAPE_MAX_RETRIES", 2)
+        max_chars = _parse_int_env("WEB_SCRAPE_MAX_CHARS", 200_000)
+        ingest_enabled = _parse_bool_env("WEB_SCRAPE_INGEST_ENABLED", False)
+        return WebScrapeConfig(
+            provider=provider,
+            api_key=api_key,
+            endpoint=endpoint or "https://r.jina.ai",
+            timeout_seconds=max(1.0, timeout_seconds),
+            max_retries=max(0, max_retries),
+            max_chars=max(1_000, max_chars),
+            ingest_enabled=ingest_enabled,
+        )
+
     # ------------------------------------------------------
     # VALIDATION
     # ------------------------------------------------------
@@ -540,7 +693,7 @@ class Settings:
 
 
 # ==========================================================
-# 🔹 SINGLETON INSTANCE
+#  SINGLETON INSTANCE
 # ==========================================================
 
 settings = Settings()

--- a/tests/test_external_knowledge_ingestion.py
+++ b/tests/test_external_knowledge_ingestion.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import httpx
+
+os.environ.setdefault("OPENROUTER_API_KEY", "test-openrouter-key")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+
+# Other tests may install lightweight module doubles during collection. These
+# tests need the real ingestion module and web-ingestion module.
+sys.modules.pop("agents.multimodal.ingestion", None)
+sys.modules.pop("agents.furnacemind.web_ingestion", None)
+
+from agents.furnacemind import web_ingestion as web_ingestion_module  # noqa: E402
+from agents.furnacemind.web_ingestion import (  # noqa: E402
+    JinaReaderProvider,
+    ingest_external_knowledge_url,
+)
+from utils.settings import WebScrapeConfig  # noqa: E402
+
+
+class _FakeResponse:
+    """Small response double for Jina Reader provider tests."""
+
+    def __init__(
+        self,
+        text: str = "",
+        *,
+        headers: dict[str, str] | None = None,
+        status_error: Exception | None = None,
+    ):
+        self.text = text
+        self.headers = headers or {}
+        self.status_error = status_error
+
+    def raise_for_status(self) -> None:
+        """Raise a configured HTTP-status error, if one was supplied."""
+        if self.status_error:
+            raise self.status_error
+
+
+class _FakeClient:
+    """Context-manager HTTP client that replays configured responses/errors."""
+
+    def __init__(self, factory: "_FakeClientFactory", *, timeout: float):
+        self.factory = factory
+        self.timeout = timeout
+
+    def __enter__(self) -> "_FakeClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+    def get(self, url: str, *, headers: dict | None = None) -> _FakeResponse:
+        """Record request details and return or raise the next configured item."""
+        self.factory.calls.append(
+            {
+                "url": url,
+                "headers": headers or {},
+                "timeout": self.timeout,
+            }
+        )
+        item = self.factory.items.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _FakeClientFactory:
+    """Factory object matching the ``httpx.Client`` constructor shape."""
+
+    def __init__(self, items: list[_FakeResponse | Exception]):
+        self.items = list(items)
+        self.calls: list[dict] = []
+
+    def __call__(self, *, timeout: float) -> _FakeClient:
+        return _FakeClient(self, timeout=timeout)
+
+
+class _FakeEmbedding:
+    """Deterministic text embedding client for ingestion tests."""
+
+    dimension = 3
+
+    def embed_text(self, text: str, *, input_type: str | None = None) -> list[float]:
+        assert text.strip()
+        assert input_type == "document"
+        return [0.1, 0.2, 0.3]
+
+
+class _FakeQdrantClient:
+    """Qdrant client stand-in recording upsert payloads."""
+
+    def __init__(self) -> None:
+        self.upsert_calls: list[dict] = []
+
+    def upsert(self, **kwargs) -> None:
+        self.upsert_calls.append(kwargs)
+
+
+class _FakeDocumentRepository:
+    """SQL repository stand-in recording document and raw-byte writes."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict] = []
+        self.store_calls: list[dict] = []
+        self.documents: list[SimpleNamespace] = []
+
+    def list_documents(self, *, user_id: str | None = None, active_only: bool = True):
+        return list(self.documents)
+
+    def create_document(self, **kwargs) -> object:
+        self.create_calls.append(kwargs)
+        document = SimpleNamespace(
+            document_id="sql-doc-1",
+            metadata_json={
+                "document_id": kwargs["metadata"]["document_id"],
+                "qdrant_point_ids": kwargs["qdrant_point_ids"],
+            },
+        )
+        self.documents.append(document)
+        return document
+
+    def store_document_file(self, **kwargs) -> None:
+        self.store_calls.append(kwargs)
+
+
+class _FakeChunkRepository:
+    """SQL chunk repository stand-in recording chunk writes."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict] = []
+
+    def create_chunks(self, **kwargs) -> int:
+        self.create_calls.append(kwargs)
+        return len(kwargs["parts"])
+
+
+def _config(**overrides) -> WebScrapeConfig:  # noqa: ANN003
+    """Return a Jina Reader config suitable for unit tests."""
+    values = {
+        "provider": "jina_reader",
+        "api_key": None,
+        "endpoint": "https://r.jina.ai",
+        "timeout_seconds": 3.0,
+        "max_retries": 0,
+        "max_chars": 1000,
+    }
+    values.update(overrides)
+    return WebScrapeConfig(**values)
+
+
+def test_jina_reader_provider_returns_normalized_markdown_page() -> None:
+    """Jina Reader output should become clean source text with metadata."""
+    factory = _FakeClientFactory(
+        [
+            _FakeResponse(
+                "Title: Blast Furnace Coke Quality\n\n"
+                "URL Source: https://example.com/bf-coke\n\n"
+                "Markdown Content:\n# Coke quality\n\n"
+                "CSR and CRI affect blast furnace fuel demand."
+            )
+        ]
+    )
+    provider = JinaReaderProvider(_config(), client_factory=factory)
+
+    response = provider.fetch("https://example.com/bf-coke")
+
+    assert response.error is None
+    assert response.page is not None
+    assert response.page.title == "Blast Furnace Coke Quality"
+    assert "CSR and CRI" in response.page.content
+    assert "URL Source:" not in response.page.content
+    assert response.page.provider == "jina_reader"
+    assert response.page.sha256
+    assert factory.calls[0]["url"] == "https://r.jina.ai/https://example.com/bf-coke"
+    assert factory.calls[0]["headers"]["X-Return-Format"] == "markdown"
+    assert "Authorization" not in factory.calls[0]["headers"]
+
+
+def test_jina_reader_provider_rejects_non_http_urls() -> None:
+    """Only absolute public web URLs should be accepted for scraping."""
+    provider = JinaReaderProvider(_config())
+
+    response = provider.fetch("file:///etc/passwd")
+
+    assert response.page is None
+    assert "http/https" in response.error
+
+
+def test_jina_reader_provider_retries_timeout_and_returns_error(monkeypatch) -> None:
+    """Timeouts should retry within the configured budget and then degrade."""
+    monkeypatch.setattr(web_ingestion_module.time, "sleep", lambda _: None)
+    factory = _FakeClientFactory(
+        [
+            httpx.TimeoutException("slow page"),
+            httpx.TimeoutException("still slow"),
+        ]
+    )
+    provider = JinaReaderProvider(_config(max_retries=1), client_factory=factory)
+
+    response = provider.fetch("https://example.com/slow")
+
+    assert len(factory.calls) == 2
+    assert response.page is None
+    assert "timed out" in response.error
+
+
+def test_jina_reader_provider_adds_authorization_header() -> None:
+    """Configured Jina API keys should be sent as bearer tokens."""
+    factory = _FakeClientFactory(
+        [
+            _FakeResponse(
+                "Title: BF Article\n\nMarkdown Content:\nBlast furnace operating notes."
+            )
+        ]
+    )
+    provider = JinaReaderProvider(
+        _config(api_key="jina-test-key"), client_factory=factory
+    )
+
+    response = provider.fetch("https://example.com/bf")
+
+    assert response.ok
+    assert factory.calls[0]["headers"]["Authorization"] == "Bearer jina-test-key"
+
+
+def test_ingest_external_knowledge_url_writes_shared_knowledge_metadata() -> None:
+    """Scraped pages should reuse MRAG SQL, chunk, and Qdrant persistence."""
+    provider = JinaReaderProvider(
+        _config(),
+        client_factory=_FakeClientFactory(
+            [
+                _FakeResponse(
+                    "Title: Cast House SOP\n\n"
+                    "URL Source: https://example.com/cast-house-sop\n\n"
+                    "Markdown Content:\n"
+                    + "Runner dryness and taphole checks are required "
+                    "before tapping.\n" * 40,
+                )
+            ]
+        ),
+    )
+    qdrant_client = _FakeQdrantClient()
+    store = SimpleNamespace(
+        client=qdrant_client,
+        collection_name="furnacemind_knowledge",
+        embedding_dim=3,
+    )
+    document_repository = _FakeDocumentRepository()
+    chunk_repository = _FakeChunkRepository()
+
+    result = ingest_external_knowledge_url(
+        "https://example.com/cast-house-sop",
+        knowledge_store=store,
+        embedding_client=_FakeEmbedding(),
+        user_id="user-1",
+        document_repository=document_repository,
+        chunk_repository=chunk_repository,
+        provider=provider,
+    )
+
+    assert result.status == "indexed"
+    assert result.chunk_count > 0
+    assert result.sql_document_id == "sql-doc-1"
+    assert result.qdrant_collection == "furnacemind_knowledge"
+    assert result.filename.endswith(".md")
+
+    point = qdrant_client.upsert_calls[0]["points"][0]
+    assert point.payload["source_type"] == "web_scrape"
+    assert point.payload["source_url"] == "https://example.com/cast-house-sop"
+    assert point.payload["title"] == "Cast House SOP"
+
+    create_call = document_repository.create_calls[0]
+    assert create_call["metadata"]["source_type"] == "web_scrape"
+    assert create_call["metadata"]["source_url"] == "https://example.com/cast-house-sop"
+    assert create_call["metadata"]["title"] == "Cast House SOP"
+
+    store_call = document_repository.store_calls[0]
+    assert store_call["content_type"] == "text/markdown; charset=utf-8"
+    assert b"Runner dryness" in store_call["file_bytes"]
+    assert chunk_repository.create_calls
+
+
+def test_ingest_external_knowledge_url_does_not_raise_on_empty_page() -> None:
+    """Empty Jina Reader output should return an unavailable ingestion result."""
+    provider = JinaReaderProvider(
+        _config(),
+        client_factory=_FakeClientFactory([_FakeResponse("")]),
+    )
+    store = SimpleNamespace(
+        client=_FakeQdrantClient(),
+        collection_name="furnacemind_knowledge",
+        embedding_dim=3,
+    )
+
+    result = ingest_external_knowledge_url(
+        "https://example.com/empty",
+        knowledge_store=store,
+        embedding_client=_FakeEmbedding(),
+        provider=provider,
+    )
+
+    assert result.status == "unavailable"
+    assert "empty content" in result.error
+
+
+def test_ingest_external_knowledge_url_skips_existing_source_url() -> None:
+    """Existing source URLs should not be re-embedded into Qdrant."""
+    provider = JinaReaderProvider(
+        _config(),
+        client_factory=_FakeClientFactory(
+            [
+                _FakeResponse(
+                    "Title: Cast House SOP\n\n"
+                    "URL Source: https://example.com/cast-house-sop\n\n"
+                    "Markdown Content:\nRunner dryness and taphole checks are required "
+                    "before tapping.",
+                )
+            ]
+        ),
+    )
+    qdrant_client = _FakeQdrantClient()
+    store = SimpleNamespace(
+        client=qdrant_client,
+        collection_name="furnacemind_knowledge",
+        embedding_dim=3,
+    )
+    document_repository = _FakeDocumentRepository()
+    document_repository.documents.append(
+        SimpleNamespace(
+            document_id="sql-existing",
+            filename="web_existing.md",
+            qdrant_collection="furnacemind_knowledge",
+            metadata_json={
+                "document_id": "doc-existing",
+                "source_url": "https://example.com/cast-house-sop",
+                "chunk_count": 2,
+            },
+            sha256=None,
+        )
+    )
+
+    result = ingest_external_knowledge_url(
+        "https://example.com/cast-house-sop",
+        knowledge_store=store,
+        embedding_client=_FakeEmbedding(),
+        document_repository=document_repository,
+        provider=provider,
+    )
+
+    assert result.status == "already_indexed"
+    assert result.sql_document_id == "sql-existing"
+    assert result.document_id == "doc-existing"
+    assert result.chunk_count == 2
+    assert qdrant_client.upsert_calls == []
+    assert document_repository.create_calls == []

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import httpx
+
+
+def _install_plotly_stubs() -> None:
+    """Install lightweight Plotly stubs before importing furnace_tools."""
+    plotly = types.ModuleType("plotly")
+    express = types.ModuleType("plotly.express")
+    graph_objects = types.ModuleType("plotly.graph_objects")
+    subplots = types.ModuleType("plotly.subplots")
+    subplots.make_subplots = lambda *args, **kwargs: None
+    plotly.express = express
+    plotly.graph_objects = graph_objects
+    plotly.subplots = subplots
+    sys.modules.setdefault("plotly", plotly)
+    sys.modules.setdefault("plotly.express", express)
+    sys.modules.setdefault("plotly.graph_objects", graph_objects)
+    sys.modules.setdefault("plotly.subplots", subplots)
+
+
+def _install_langchain_tool_stub() -> None:
+    """Install a no-op LangChain tool decorator for import-only tests."""
+    langchain = types.ModuleType("langchain")
+    tools = types.ModuleType("langchain.tools")
+
+    def tool(func=None, *args, **kwargs):  # noqa: ANN001, ANN202, ARG001
+        if func is None:
+            return lambda wrapped: wrapped
+        return func
+
+    tools.tool = tool
+    langchain.tools = tools
+    sys.modules.setdefault("langchain", langchain)
+    sys.modules.setdefault("langchain.tools", tools)
+
+
+_install_plotly_stubs()
+_install_langchain_tool_stub()
+
+from agents import furnace_tools  # noqa: E402
+from agents.furnacemind.web_search import BraveSearchProvider  # noqa: E402
+from utils.settings import WebSearchConfig  # noqa: E402
+
+
+class _FakeResponse:
+    """Small response double for Brave provider unit tests."""
+
+    def __init__(
+        self, payload: dict | None = None, *, status_error: Exception | None = None
+    ):
+        self.payload = payload or {}
+        self.status_error = status_error
+
+    def raise_for_status(self) -> None:
+        """Raise a configured HTTP-status error, if one was supplied."""
+        if self.status_error:
+            raise self.status_error
+
+    def json(self) -> dict:
+        """Return the configured JSON payload."""
+        return self.payload
+
+
+class _FakeClient:
+    """Context-manager HTTP client that replays configured responses/errors."""
+
+    def __init__(self, factory: "_FakeClientFactory", *, timeout: float):
+        self.factory = factory
+        self.timeout = timeout
+
+    def __enter__(self) -> "_FakeClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+    def get(self, url: str, *, headers: dict, params: dict) -> _FakeResponse:
+        """Record request details and return or raise the next configured item."""
+        self.factory.calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": self.timeout,
+            }
+        )
+        item = self.factory.items.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _FakeClientFactory:
+    """Factory object matching the ``httpx.Client`` constructor shape."""
+
+    def __init__(self, items: list[_FakeResponse | Exception]):
+        self.items = list(items)
+        self.calls: list[dict] = []
+
+    def __call__(self, *, timeout: float) -> _FakeClient:
+        return _FakeClient(self, timeout=timeout)
+
+
+def _config(**overrides) -> WebSearchConfig:  # noqa: ANN003
+    """Return a Brave web-search config suitable for unit tests."""
+    values = {
+        "provider": "brave",
+        "api_key": "test-token",
+        "endpoint": "https://search.example.test",
+        "max_results": 5,
+        "timeout_seconds": 3.0,
+        "max_retries": 0,
+    }
+    values.update(overrides)
+    return WebSearchConfig(**values)
+
+
+def test_brave_provider_returns_standard_results() -> None:
+    """Brave responses should normalize into source-citable results."""
+    factory = _FakeClientFactory(
+        [
+            _FakeResponse(
+                {
+                    "web": {
+                        "results": [
+                            {
+                                "title": "Blast furnace reference",
+                                "url": "https://example.com/bf",
+                                "description": "Current public reference summary.",
+                            }
+                        ]
+                    }
+                }
+            )
+        ]
+    )
+    provider = BraveSearchProvider(_config(), client_factory=factory)
+
+    response = provider.search(query="latest blast furnace guidance", limit=3)
+
+    assert response.error is None
+    assert response.results[0].title == "Blast furnace reference"
+    assert response.results[0].url == "https://example.com/bf"
+    assert response.results[0].snippet == "Current public reference summary."
+    assert factory.calls[0]["headers"]["X-Subscription-Token"] == "test-token"
+    assert factory.calls[0]["params"] == {
+        "q": "latest blast furnace guidance",
+        "count": 3,
+        "text_decorations": "false",
+    }
+
+
+def test_brave_provider_empty_results_render_no_result_status() -> None:
+    """Empty provider results should be explicit instead of raising."""
+    factory = _FakeClientFactory([_FakeResponse({"web": {"results": []}})])
+    provider = BraveSearchProvider(_config(), client_factory=factory)
+
+    response = provider.search(query="no matching result")
+
+    assert response.error is None
+    assert response.results == []
+    assert "Status: no_results" in response.to_tool_text()
+
+
+def test_brave_provider_missing_api_key_is_graceful() -> None:
+    """A missing API key should make the optional tool unavailable, not crash."""
+    provider = BraveSearchProvider(_config(api_key=None))
+
+    response = provider.search(query="current public info")
+
+    assert response.results == []
+    assert "BRAVE_SEARCH_API_KEY" in response.error
+    assert "Status: unavailable" in response.to_tool_text()
+
+
+def test_brave_provider_retries_timeout_and_returns_error(monkeypatch) -> None:
+    """Timeouts should retry within the configured budget and then degrade."""
+    from agents.furnacemind import web_search as web_search_module
+
+    monkeypatch.setattr(web_search_module.time, "sleep", lambda _: None)
+    factory = _FakeClientFactory(
+        [
+            httpx.TimeoutException("slow provider"),
+            httpx.TimeoutException("still slow"),
+        ]
+    )
+    provider = BraveSearchProvider(
+        _config(max_retries=1),
+        client_factory=factory,
+    )
+
+    response = provider.search(query="latest external standard")
+
+    assert len(factory.calls) == 2
+    assert response.results == []
+    assert "timed out" in response.error
+
+
+def test_web_search_tool_schema_and_dispatch(monkeypatch) -> None:
+    """The FurnaceMind tool registry should expose and dispatch web_search."""
+    monkeypatch.setattr(
+        furnace_tools.st,
+        "session_state",
+        {"fm_web_search_enabled": True},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        furnace_tools,
+        "search_web",
+        lambda query, *, limit=None: f"searched {query} limit={limit}",
+    )
+
+    tool_names = {
+        schema["function"]["name"] for schema in furnace_tools.get_openai_tool_schemas()
+    }
+    result = furnace_tools.execute_openai_tool_call(
+        name="web_search",
+        arguments={"query": "latest coke CSR reference", "limit": 2},
+    )
+
+    assert "web_search" in tool_names
+    assert result == "searched latest coke CSR reference limit=2"
+
+
+def test_web_search_tool_respects_sidebar_toggle(monkeypatch) -> None:
+    """Disabled live web search should not call the Brave provider."""
+    monkeypatch.setattr(
+        furnace_tools.st,
+        "session_state",
+        {"fm_web_search_enabled": False},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        furnace_tools,
+        "search_web",
+        lambda *_, **__: (_ for _ in ()).throw(AssertionError("search_web called")),
+    )
+
+    result = furnace_tools.web_search(query="latest blast furnace news")
+
+    assert "web_search disabled" in result
+
+
+def test_web_search_tool_validation_returns_error(monkeypatch) -> None:
+    """Invalid model-generated search arguments should return a tool error."""
+    monkeypatch.setattr(furnace_tools, "_append_tool_error", lambda **_: None)
+
+    result = furnace_tools.web_search(query="")
+
+    assert result.startswith("web_search Error:")
+
+
+def test_web_scrape_ingest_tool_schema_and_dispatch(monkeypatch) -> None:
+    """The tool registry should expose and dispatch approved URL ingestion."""
+    monkeypatch.setattr(
+        furnace_tools,
+        "settings",
+        types.SimpleNamespace(web_scrape=types.SimpleNamespace(ingest_enabled=True)),
+    )
+    state = {
+        "knowledge_store": object(),
+        "knowledge_embedding_client": object(),
+        "fm_user_id": "user-1",
+        "knowledge_document_repository": object(),
+        "knowledge_chunk_repository": object(),
+    }
+    monkeypatch.setattr(furnace_tools.st, "session_state", state, raising=False)
+    calls = {}
+
+    def fake_ingest(url, **kwargs):  # noqa: ANN001, ANN202
+        calls["url"] = url
+        calls["kwargs"] = kwargs
+        return types.SimpleNamespace(
+            status="indexed",
+            url=url,
+            filename="web_source.md",
+            document_id="doc-1",
+            sql_document_id="sql-doc-1",
+            chunk_count=3,
+            qdrant_collection="furnacemind_knowledge",
+            error=None,
+        )
+
+    monkeypatch.setattr(furnace_tools, "ingest_external_knowledge_url", fake_ingest)
+
+    tool_names = {
+        schema["function"]["name"] for schema in furnace_tools.get_openai_tool_schemas()
+    }
+    result = furnace_tools.execute_openai_tool_call(
+        name="web_scrape_ingest",
+        arguments={"url": "https://example.com/blast-furnace-sop"},
+    )
+
+    assert "web_scrape_ingest" in tool_names
+    assert "Status: indexed" in result
+    assert "Chunks indexed: 3" in result
+    assert calls["url"] == "https://example.com/blast-furnace-sop"
+    assert calls["kwargs"]["knowledge_store"] is state["knowledge_store"]
+    assert calls["kwargs"]["embedding_client"] is state["knowledge_embedding_client"]
+    assert calls["kwargs"]["user_id"] == "user-1"
+
+
+def test_web_scrape_ingest_requires_initialized_knowledge_store(monkeypatch) -> None:
+    """The scraper tool should fail gracefully before page setup is ready."""
+    monkeypatch.setattr(
+        furnace_tools,
+        "settings",
+        types.SimpleNamespace(web_scrape=types.SimpleNamespace(ingest_enabled=True)),
+    )
+    monkeypatch.setattr(
+        furnace_tools.st,
+        "session_state",
+        {"knowledge_embedding_client": object()},
+        raising=False,
+    )
+
+    result = furnace_tools.web_scrape_ingest(url="https://example.com/source")
+
+    assert "Knowledge store is not initialized" in result
+
+
+def test_web_scrape_ingest_rejects_non_http_url(monkeypatch) -> None:
+    """The tool should reject local or non-web targets before scraping."""
+    monkeypatch.setattr(furnace_tools, "_append_tool_error", lambda **_: None)
+
+    result = furnace_tools.web_scrape_ingest(url="file:///tmp/source.md")
+
+    assert result == "web_scrape_ingest Error: URL must be an absolute http/https URL."
+
+
+def test_web_scrape_ingest_returns_provider_failure(monkeypatch) -> None:
+    """Provider failures should become a normal tool message, not an exception."""
+    monkeypatch.setattr(
+        furnace_tools,
+        "settings",
+        types.SimpleNamespace(web_scrape=types.SimpleNamespace(ingest_enabled=True)),
+    )
+    monkeypatch.setattr(
+        furnace_tools.st,
+        "session_state",
+        {
+            "knowledge_store": object(),
+            "knowledge_embedding_client": object(),
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        furnace_tools,
+        "ingest_external_knowledge_url",
+        lambda url, **kwargs: types.SimpleNamespace(
+            status="unavailable",
+            url=url,
+            filename=None,
+            document_id=None,
+            sql_document_id=None,
+            chunk_count=0,
+            qdrant_collection=None,
+            error="Scrape request timed out.",
+        ),
+    )
+
+    result = furnace_tools.web_scrape_ingest(url="https://example.com/slow")
+
+    assert "Status: unavailable" in result
+    assert "Scrape request timed out" in result
+
+
+def test_web_scrape_ingest_disabled_by_config(monkeypatch) -> None:
+    """Permanent URL ingestion should require an explicit config enable flag."""
+    monkeypatch.setattr(
+        furnace_tools,
+        "settings",
+        types.SimpleNamespace(web_scrape=types.SimpleNamespace(ingest_enabled=False)),
+    )
+
+    result = furnace_tools.web_scrape_ingest(url="https://example.com/source")
+
+    assert "WEB_SCRAPE_INGEST_ENABLED=true" in result

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -4,6 +4,7 @@ import sys
 import types
 
 import httpx
+import pytest
 
 
 def _install_plotly_stubs() -> None:
@@ -42,17 +43,37 @@ _install_plotly_stubs()
 _install_langchain_tool_stub()
 
 from agents import furnace_tools  # noqa: E402
-from agents.furnacemind.web_search import BraveSearchProvider  # noqa: E402
-from utils.settings import WebSearchConfig  # noqa: E402
+from agents.furnacemind import web_search as web_search_module  # noqa: E402
+from agents.furnacemind.web_search import (  # noqa: E402
+    BraveSearchAdapter,
+    DuckDuckGoSearchAdapter,
+    ExaSearchAdapter,
+    FirecrawlSearchAdapter,
+    ParallelSearchAdapter,
+    SearXNGSearchAdapter,
+    SerperSearchAdapter,
+    TavilySearchAdapter,
+    WebSearchResponse,
+    WhoogleSearchAdapter,
+    YaCySearchAdapter,
+    build_web_search_provider,
+    register_web_search_provider,
+)
+from utils.settings import Settings, WebSearchConfig  # noqa: E402
 
 
 class _FakeResponse:
-    """Small response double for Brave provider unit tests."""
+    """Small response double for JSON and HTML provider unit tests."""
 
     def __init__(
-        self, payload: dict | None = None, *, status_error: Exception | None = None
+        self,
+        payload: dict | None = None,
+        *,
+        text: str = "",
+        status_error: Exception | None = None,
     ):
         self.payload = payload or {}
+        self.text = text
         self.status_error = status_error
 
     def raise_for_status(self) -> None:
@@ -80,12 +101,31 @@ class _FakeClient:
 
     def get(self, url: str, *, headers: dict, params: dict) -> _FakeResponse:
         """Record request details and return or raise the next configured item."""
+        return self._send(
+            method="GET",
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+    def post(self, url: str, *, headers: dict, json: dict) -> _FakeResponse:
+        """Record a JSON POST and return or raise the next configured item."""
+        return self._send(
+            method="POST",
+            url=url,
+            headers=headers,
+            json=json,
+        )
+
+    def _send(self, *, method: str, url: str, headers: dict, **data) -> _FakeResponse:
+        """Record common request details and replay one response or exception."""
         self.factory.calls.append(
             {
+                "method": method,
                 "url": url,
                 "headers": headers,
-                "params": params,
                 "timeout": self.timeout,
+                **data,
             }
         )
         item = self.factory.items.pop(0)
@@ -114,6 +154,7 @@ def _config(**overrides) -> WebSearchConfig:  # noqa: ANN003
         "max_results": 5,
         "timeout_seconds": 3.0,
         "max_retries": 0,
+        "max_requests_per_session": 5,
     }
     values.update(overrides)
     return WebSearchConfig(**values)
@@ -138,7 +179,7 @@ def test_brave_provider_returns_standard_results() -> None:
             )
         ]
     )
-    provider = BraveSearchProvider(_config(), client_factory=factory)
+    provider = BraveSearchAdapter(_config(), client_factory=factory)
 
     response = provider.search(query="latest blast furnace guidance", limit=3)
 
@@ -146,6 +187,7 @@ def test_brave_provider_returns_standard_results() -> None:
     assert response.results[0].title == "Blast furnace reference"
     assert response.results[0].url == "https://example.com/bf"
     assert response.results[0].snippet == "Current public reference summary."
+    assert factory.calls[0]["method"] == "GET"
     assert factory.calls[0]["headers"]["X-Subscription-Token"] == "test-token"
     assert factory.calls[0]["params"] == {
         "q": "latest blast furnace guidance",
@@ -157,7 +199,7 @@ def test_brave_provider_returns_standard_results() -> None:
 def test_brave_provider_empty_results_render_no_result_status() -> None:
     """Empty provider results should be explicit instead of raising."""
     factory = _FakeClientFactory([_FakeResponse({"web": {"results": []}})])
-    provider = BraveSearchProvider(_config(), client_factory=factory)
+    provider = BraveSearchAdapter(_config(), client_factory=factory)
 
     response = provider.search(query="no matching result")
 
@@ -168,7 +210,7 @@ def test_brave_provider_empty_results_render_no_result_status() -> None:
 
 def test_brave_provider_missing_api_key_is_graceful() -> None:
     """A missing API key should make the optional tool unavailable, not crash."""
-    provider = BraveSearchProvider(_config(api_key=None))
+    provider = BraveSearchAdapter(_config(api_key=None))
 
     response = provider.search(query="current public info")
 
@@ -179,8 +221,6 @@ def test_brave_provider_missing_api_key_is_graceful() -> None:
 
 def test_brave_provider_retries_timeout_and_returns_error(monkeypatch) -> None:
     """Timeouts should retry within the configured budget and then degrade."""
-    from agents.furnacemind import web_search as web_search_module
-
     monkeypatch.setattr(web_search_module.time, "sleep", lambda _: None)
     factory = _FakeClientFactory(
         [
@@ -188,7 +228,7 @@ def test_brave_provider_retries_timeout_and_returns_error(monkeypatch) -> None:
             httpx.TimeoutException("still slow"),
         ]
     )
-    provider = BraveSearchProvider(
+    provider = BraveSearchAdapter(
         _config(max_retries=1),
         client_factory=factory,
     )
@@ -198,6 +238,306 @@ def test_brave_provider_retries_timeout_and_returns_error(monkeypatch) -> None:
     assert len(factory.calls) == 2
     assert response.results == []
     assert "timed out" in response.error
+
+
+@pytest.mark.parametrize(
+    ("adapter_class", "provider", "payload", "method", "expected_snippet"),
+    [
+        (
+            TavilySearchAdapter,
+            "tavily",
+            {
+                "results": [
+                    {
+                        "title": "Tavily result",
+                        "url": "https://example.com/tavily",
+                        "content": "Tavily summary",
+                    }
+                ]
+            },
+            "POST",
+            "Tavily summary",
+        ),
+        (
+            ExaSearchAdapter,
+            "exa",
+            {
+                "results": [
+                    {
+                        "title": "Exa result",
+                        "url": "https://example.com/exa",
+                        "highlights": ["Exa", "highlight"],
+                    }
+                ]
+            },
+            "POST",
+            "Exa highlight",
+        ),
+        (
+            ParallelSearchAdapter,
+            "parallel",
+            {
+                "results": [
+                    {
+                        "title": "Parallel result",
+                        "url": "https://example.com/parallel",
+                        "excerpts": ["Parallel excerpt"],
+                    }
+                ]
+            },
+            "POST",
+            "Parallel excerpt",
+        ),
+        (
+            FirecrawlSearchAdapter,
+            "firecrawl",
+            {
+                "data": {
+                    "web": [
+                        {
+                            "title": "Firecrawl result",
+                            "url": "https://example.com/firecrawl",
+                            "description": "Firecrawl summary",
+                        }
+                    ]
+                }
+            },
+            "POST",
+            "Firecrawl summary",
+        ),
+        (
+            SerperSearchAdapter,
+            "serper",
+            {
+                "organic": [
+                    {
+                        "title": "Serper result",
+                        "link": "https://example.com/serper",
+                        "snippet": "Serper summary",
+                    }
+                ]
+            },
+            "POST",
+            "Serper summary",
+        ),
+        (
+            SearXNGSearchAdapter,
+            "searxng",
+            {
+                "results": [
+                    {
+                        "title": "SearXNG result",
+                        "url": "https://example.com/searxng",
+                        "content": "SearXNG summary",
+                    }
+                ]
+            },
+            "GET",
+            "SearXNG summary",
+        ),
+        (
+            WhoogleSearchAdapter,
+            "whoogle",
+            {
+                "results": [
+                    {
+                        "text": "Whoogle result",
+                        "href": "https://example.com/whoogle",
+                        "description": "Whoogle summary",
+                    }
+                ]
+            },
+            "GET",
+            "Whoogle summary",
+        ),
+        (
+            YaCySearchAdapter,
+            "yacy",
+            {
+                "channels": [
+                    {
+                        "items": [
+                            {
+                                "title": "YaCy result",
+                                "link": "https://example.com/yacy",
+                                "description": "YaCy summary",
+                            }
+                        ]
+                    }
+                ]
+            },
+            "GET",
+            "YaCy summary",
+        ),
+    ],
+)
+def test_json_provider_adapters_normalize_results(
+    adapter_class,
+    provider: str,
+    payload: dict,
+    method: str,
+    expected_snippet: str,
+) -> None:
+    """Every JSON provider should expose the same normalized result contract."""
+    factory = _FakeClientFactory([_FakeResponse(payload)])
+    adapter = adapter_class(
+        _config(provider=provider, endpoint="https://search.example.test"),
+        client_factory=factory,
+    )
+
+    response = adapter.search(query="current furnace reference", limit=2)
+
+    assert response.error is None
+    assert response.provider == provider
+    assert len(response.results) == 1
+    assert response.results[0].url.startswith("https://example.com/")
+    assert response.results[0].snippet == expected_snippet
+    assert factory.calls[0]["method"] == method
+
+
+def test_duckduckgo_adapter_parses_html_and_resolves_redirect() -> None:
+    """DuckDuckGo HTML results should become normal source-citable results."""
+    html = """
+    <div class="result">
+      <a class="result__a"
+         href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fddg">
+        DuckDuckGo result
+      </a>
+      <a class="result__snippet">DuckDuckGo summary</a>
+    </div>
+    """
+    factory = _FakeClientFactory([_FakeResponse(text=html)])
+    adapter = DuckDuckGoSearchAdapter(
+        _config(
+            provider="duckduckgo",
+            api_key=None,
+            endpoint="https://html.duckduckgo.com/html/",
+        ),
+        client_factory=factory,
+    )
+
+    response = adapter.search(query="blast furnace reference")
+
+    assert response.error is None
+    assert response.results[0].title == "DuckDuckGo result"
+    assert response.results[0].url == "https://example.com/ddg"
+    assert response.results[0].snippet == "DuckDuckGo summary"
+
+
+def test_self_hosted_provider_requires_endpoint_not_api_key() -> None:
+    """Self-hosted adapters should explain missing endpoints without requiring keys."""
+    adapter = SearXNGSearchAdapter(
+        _config(provider="searxng", api_key=None, endpoint="")
+    )
+
+    response = adapter.search(query="blast furnace reference")
+
+    assert response.results == []
+    assert "SEARXNG_SEARCH_ENDPOINT" in response.error
+    assert "API key" not in response.error
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected_provider"),
+    [
+        ("serpent", "serper"),
+        ("ddg", "duckduckgo"),
+        ("searx", "searxng"),
+        ("whoogle-search", "whoogle"),
+    ],
+)
+def test_provider_aliases_build_canonical_adapters(
+    alias: str, expected_provider: str
+) -> None:
+    """Common alternate names should resolve to canonical provider adapters."""
+    provider = build_web_search_provider(
+        _config(provider=alias, endpoint="https://search.example.test")
+    )
+
+    assert provider.provider_name == expected_provider
+
+
+def test_provider_registry_accepts_an_alternate_adapter(monkeypatch) -> None:
+    """A new provider should plug in without changing FurnaceMind tool code."""
+
+    class ExampleSearchAdapter:
+        provider_name = "example"
+
+        def __init__(self, config: WebSearchConfig) -> None:
+            self.config = config
+
+        def configuration_error(self) -> str | None:
+            return None
+
+        def search(
+            self,
+            *,
+            query: str,
+            limit: int | None = None,
+        ) -> WebSearchResponse:
+            return WebSearchResponse(
+                query=query,
+                provider=self.provider_name,
+                results=[],
+            )
+
+    monkeypatch.setattr(
+        web_search_module,
+        "_WEB_SEARCH_PROVIDER_FACTORIES",
+        dict(web_search_module._WEB_SEARCH_PROVIDER_FACTORIES),
+    )
+    register_web_search_provider("Example", ExampleSearchAdapter)
+
+    provider = build_web_search_provider(_config(provider="example"))
+    response = provider.search(query="current furnace reference")
+
+    assert provider.provider_name == "example"
+    assert response.provider == "example"
+
+
+def test_alternate_provider_uses_generic_environment_settings(monkeypatch) -> None:
+    """Non-Brave providers must not inherit Brave endpoint or credentials."""
+    monkeypatch.setenv("WEB_SEARCH_PROVIDER", "example")
+    monkeypatch.setenv("WEB_SEARCH_ENDPOINT", "https://example.test/search")
+    monkeypatch.setenv("WEB_SEARCH_API_KEY", "example-token")
+    monkeypatch.setenv("BRAVE_SEARCH_ENDPOINT", "https://brave.test/search")
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-token")
+
+    config = Settings._load_web_search_config()
+
+    assert config.provider == "example"
+    assert config.endpoint == "https://example.test/search"
+    assert config.api_key == "example-token"
+
+
+def test_tavily_provider_uses_specific_environment_settings(monkeypatch) -> None:
+    """Provider-specific values should override generic search configuration."""
+    monkeypatch.setenv("WEB_SEARCH_PROVIDER", "tavily")
+    monkeypatch.setenv("WEB_SEARCH_ENDPOINT", "https://generic.test/search")
+    monkeypatch.setenv("WEB_SEARCH_API_KEY", "generic-token")
+    monkeypatch.setenv("TAVILY_SEARCH_ENDPOINT", "https://tavily.test/search")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-token")
+
+    config = Settings._load_web_search_config()
+
+    assert config.provider == "tavily"
+    assert config.endpoint == "https://tavily.test/search"
+    assert config.api_key == "tavily-token"
+
+
+def test_serpent_environment_alias_selects_serper(monkeypatch) -> None:
+    """The requested 'serpent' spelling should configure the Serper adapter."""
+    monkeypatch.setenv("WEB_SEARCH_PROVIDER", "serpent")
+    monkeypatch.setenv("SERPER_API_KEY", "serper-token")
+    monkeypatch.delenv("WEB_SEARCH_ENDPOINT", raising=False)
+    monkeypatch.delenv("SERPER_SEARCH_ENDPOINT", raising=False)
+    monkeypatch.delenv("SERPER_ENDPOINT", raising=False)
+
+    config = Settings._load_web_search_config()
+
+    assert config.provider == "serper"
+    assert config.endpoint == "https://google.serper.dev/search"
+    assert config.api_key == "serper-token"
 
 
 def test_web_search_tool_schema_and_dispatch(monkeypatch) -> None:
@@ -224,6 +564,7 @@ def test_web_search_tool_schema_and_dispatch(monkeypatch) -> None:
 
     assert "web_search" in tool_names
     assert result == "searched latest coke CSR reference limit=2"
+    assert furnace_tools.st.session_state["fm_web_search_request_count"] == 1
 
 
 def test_web_search_tool_respects_sidebar_toggle(monkeypatch) -> None:
@@ -252,6 +593,36 @@ def test_web_search_tool_validation_returns_error(monkeypatch) -> None:
     result = furnace_tools.web_search(query="")
 
     assert result.startswith("web_search Error:")
+
+
+def test_web_search_tool_stops_at_session_limit(monkeypatch) -> None:
+    """Exhausted session quota should avoid another provider API call."""
+    state = {
+        "fm_web_search_enabled": True,
+        "fm_web_search_request_count": 2,
+    }
+    monkeypatch.setattr(furnace_tools.st, "session_state", state, raising=False)
+    monkeypatch.setattr(
+        furnace_tools.settings,
+        "web_search",
+        types.SimpleNamespace(
+            provider="example",
+            max_requests_per_session=2,
+        ),
+    )
+    monkeypatch.setattr(
+        furnace_tools,
+        "search_web",
+        lambda *_, **__: (_ for _ in ()).throw(
+            AssertionError("provider should not be called")
+        ),
+    )
+
+    result = furnace_tools.web_search(query="latest furnace news")
+
+    assert "Status: session_limit_reached" in result
+    assert "Session requests used: 2/2" in result
+    assert state["fm_web_search_request_count"] == 2
 
 
 def test_web_scrape_ingest_tool_schema_and_dispatch(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

This PR adds web search and external web-source ingestion to FurnaceMind. It allows the assistant to retrieve current information through Brave Search and permanently add approved technical web content to the shared knowledge base using Jina Reader.


## Problem

FurnaceMind previously relied only on internal tools and existing knowledge documents. It could not:

- Retrieve current news, articles, or external references.
- Add technical information from a public URL to the knowledge base.
- Provide web source links for time-sensitive answers.
- Let users control whether internet search is available during chat.


## Solution

- Added a provider-isolated Brave Search integration.
- Added a Web Search toggle in the FurnaceMind sidebar.
- Added Jina Reader-based URL scraping and ingestion.
- Added a **Scrape & Index URL** interface under **Multimodal Knowledge**.
- Stored the extracted source document and metadata in PostgreSQL.
- Chunked and embedded extracted content into the `furnacemind_knowledge` Qdrant collection.
- Updated agent prompts and tool registration for correct routing.
- Added graceful handling for missing keys, timeouts, empty results, and provider failures.
- Added source URLs to responses where web evidence is used.


## Feature Flow

### Web Search

1. The user enables **Web Search**.
2. FurnaceMind identifies that the question requires current external information.
3. The agent calls the Brave Search tool.
4. Structured results containing titles, URLs, and snippets are returned.
5. FurnaceMind generates an answer with source attribution.
6. Search results are **not** permanently stored.

### Web-Source Ingestion

1. The user enters a public URL under **Multimodal Knowledge**.
2. Jina Reader extracts readable content from the page.
3. The extracted document and metadata are stored in PostgreSQL.
4. The content is chunked and embedded into Qdrant.
5. FurnaceMind can retrieve the indexed content through the existing MRAG knowledge flow.


## Changed Files

| File | Description |
|------|-------------|
| `src/agents/furnacemind/web_search.py` | Implements Brave Search, structured results, retry handling, and graceful failures. |
| `src/agents/furnacemind/web_ingestion.py` | Implements Jina Reader extraction, duplicate detection, SQL persistence, chunking, and Qdrant indexing. |
| `src/agents/furnace_tools.py` | Registers and dispatches the web search and web ingestion tools. |
| `src/agents/furnacemind/prompts.py` | Adds routing guidance for live web search, URL ingestion, and stored knowledge retrieval. |
| `src/agents/furnacemind/graph.py` | Supports web tools in the agent workflow and handles tool failures without crashing the conversation. |
| `src/agents/furnacemind/ai_cooperate_page.py` | Adds the user-controlled Web Search toggle. |
| `src/ui/furnacemind/chat_interface.py` | Adds the URL ingestion interface to the knowledge sidebar. |
| `src/agents/multimodal/ingestion.py` | Supports web-derived documents in the existing knowledge ingestion pipeline. |
| `furnace_data/furnace_data/relational/repositories.py` | Supports storing and retrieving document bytes, content type, size, and SHA-256 metadata safely. |
| `src/utils/settings.py` | Adds Brave Search and Jina Reader configuration. |
| `tests/test_web_search_tool.py` | Covers successful searches, empty results, timeouts, missing configuration, and service failures. |
| `tests/test_external_knowledge_ingestion.py` | Covers URL extraction, SQL storage, duplicate detection, chunking, indexing, and failure handling. |


## Testing

- Brave Search responses and source attribution verified.
- Web Search enabled and disabled behavior verified.
- Jina Reader URL ingestion verified.
- PostgreSQL document storage verified.
- Qdrant chunk indexing and retrieval verified.
- Automated tests passed: **19 passed**.


## Configuration

The required API credentials are supplied through environment variables or deployment secrets and are **not** committed to the repository.

```text
BRAVE_SEARCH_API_KEY
JINA_READER_API_KEY
```