### PR TITLE
fix(bmo): separate blend selection from fuel estimation

### DIFF
--- a/src/assets/data/cache_meta.json
+++ b/src/assets/data/cache_meta.json
@@ -4,10 +4,10 @@
   "data_start": "2025-04-01",
   "confirmed_end": "2026-08-11",
   "raw_end": "2026-08-11",
-  "last_updated": "2026-08-13T15:28:35",
+  "last_updated": "2026-08-16T03:31:57",
   "offline_lag_days": 0,
   "rows": 6515,
   "columns": 156,
-  "csv_file": "furnace_dataset_20260813_152833_918452.csv",
+  "csv_file": "furnace_dataset_20260816_033155_080420.csv",
   "source_url": "http://125.23.100.62:8081/furnace_dataset.csv"
 }

--- a/src/custom_pages/9_Blend_Optimizer.py
+++ b/src/custom_pages/9_Blend_Optimizer.py
@@ -1021,6 +1021,16 @@ def _render_blend_comparison(
             "{:,.3f}",
         ),
         (
+            # Constrained. Plant runs ~1.31.
+            "Slag T-Basicity (CaO+MgO)/SiO2",
+            lambda b, si: _basicity(
+                b, "slag_t_basicity_denominator_mt", "slag_t_basicity"
+            ),
+            "{:,.3f}",
+        ),
+        (
+            # Display only. Reads ~0.84 at the plant, not ~1.31, because Al2O3
+            # joins the denominator - the two are easily mistaken for each other.
             "IB4 (CaO+MgO)/(SiO2+Al2O3)",
             lambda b, si: _basicity(b, "slag_ib4_denominator_mt", "slag_ib4"),
             "{:,.3f}",
@@ -2362,6 +2372,18 @@ else:
 
 with st.form("bmo_fuel_ash_input_form", clear_on_submit=False):
     st.markdown("### Fuel Ash Inputs")
+    st.caption(
+        "**These rows exist to put fuel ash into the slag balance.** The rate and "
+        "ash chemistry of each fuel decide how much ash it charges, and that ash "
+        "is part of the slag the LP constrains. Set a fuel's rate to 0 to drop its "
+        "ash from the slag entirely - nothing else changes."
+    )
+    st.caption(
+        "Two columns are also read by the separate fuel-cost step, which runs "
+        "AFTER the LP and never feeds back into slag: the **prices**, and the "
+        "**nut coke and PCI rates**. Coke rate is not read there at all - it is "
+        "back-solved from the model's predicted cost."
+    )
     if not fuel_ash_editor_source_df.empty:
         edited_fuel_ash_candidate_df = render_fuel_ash_editor(fuel_ash_editor_source_df)
     else:

--- a/src/ui/bmo/components.py
+++ b/src/ui/bmo/components.py
@@ -1238,7 +1238,17 @@ def render_blend_metrics(
         )
 
     # Row 3: workbook-comparable slag ratios from the final slag ledger.
-    b1, b2 = st.columns(2)
+    #
+    # All three are shown together because they are easy to confuse: they share a
+    # numerator or a denominator but sit on completely different scales. Plant
+    # reference over 6,515 hours of HM_SLAG analysis:
+    #     B2   = CaO/SiO2               mean 1.079,  p5-p95 1.005 - 1.155
+    #     T.B  = (CaO+MgO)/SiO2         mean 1.309,  p5-p95 1.216 - 1.403
+    #     IB4  = (CaO+MgO)/(SiO2+Al2O3) mean 0.844,  p5-p95 0.793 - 0.902
+    # IB4 reads far lower than T Basicity purely because Al2O3 (~18.7% of slag)
+    # joins its denominator - a ~0.85 IB4 is normal, not a fault. T Basicity is
+    # the one that is actually constrained, so it must stay visible.
+    b1, b2, b3 = st.columns(3)
     basicity_denominator_mt = float(
         blend.diagnostics.get("slag_basicity_denominator_mt", 0.0) or 0.0
     )
@@ -1246,17 +1256,36 @@ def render_blend_metrics(
         b1.metric("Slag Basicity CaO/SiO2", f"{blend.slag_basicity:,.3f}")
     else:
         b1.metric("Slag Basicity CaO/SiO2", "n/a")
+    t_basicity_denominator_mt = float(
+        blend.diagnostics.get("slag_t_basicity_denominator_mt", 0.0) or 0.0
+    )
+    if t_basicity_denominator_mt > 0:
+        b2.metric(
+            "Slag T Basicity",
+            f"{blend.slag_t_basicity:,.3f}",
+            help=(
+                "(CaO + MgO) / SiO2, from final slag components. This is the "
+                "ratio the optimizer constrains via the Min/Max T Basicity "
+                "inputs. Plant runs ~1.31."
+            ),
+        )
+    else:
+        b2.metric("Slag T Basicity", "n/a")
     ib4_denominator_mt = float(
         blend.diagnostics.get("slag_ib4_denominator_mt", 0.0) or 0.0
     )
     if ib4_denominator_mt > 0:
-        b2.metric(
+        b3.metric(
             "IB4",
             f"{blend.slag_ib4:,.3f}",
-            help="(CaO + MgO) / (SiO2 + Al2O3), from final slag components.",
+            help=(
+                "(CaO + MgO) / (SiO2 + Al2O3), from final slag components. "
+                "Display only - not constrained. Reads much lower than T "
+                "Basicity because Al2O3 is in the denominator; plant runs ~0.84."
+            ),
         )
     else:
-        b2.metric("IB4", "n/a")
+        b3.metric("IB4", "n/a")
 
     dust_usage = [
         row

--- a/src/utils/bmo/fuel_prediction.py
+++ b/src/utils/bmo/fuel_prediction.py
@@ -210,6 +210,7 @@ def evaluate_blend_with_fuel_prediction(
     coke_correction_settings: CokeCorrectionSettings | None = None,
     coke_correction_reference: CokeCorrectionReference | None = None,
     hot_metal_si_pct: float | None = None,
+    recompute_slag_with_corrected_fuel: bool = False,
 ) -> BlendEvaluation:
     """
     Evaluate a blend and attach the model-predicted fuel unit cost.
@@ -217,6 +218,21 @@ def evaluate_blend_with_fuel_prediction(
     LP optimization still decides quantities from ore economics and physical
     constraints. This helper is used after a quantity vector exists so LP and
     DE results can both show a comparable fuel-cost prediction.
+
+    The slag balance and the fuel estimate are two SEPARATE stages, and by
+    default the second does not feed back into the first:
+
+    1. Slag is computed from the blend plus the fuel-ash rates the operator
+       entered in the Fuel Ash table. That is the slag the LP constrained, and
+       it is what gets displayed.
+    2. The fuel estimate then predicts unit cost from the blend, back-solves a
+       coke rate against the table's prices, and applies the physics coke
+       correction. This is REPORTING only.
+
+    Letting stage 2 rewrite stage 1 is what made the displayed basicity differ
+    from the basicity the LP actually solved for. ``recompute_slag_with_corrected_fuel``
+    restores the old feedback and exists only for DE, whose objective genuinely
+    prices the corrected fuel and therefore needs slag on the same basis.
 
     Args:
          - ores: list[OreInput] - Ores included in the solved blend.
@@ -324,11 +340,21 @@ def evaluate_blend_with_fuel_prediction(
             fuel_rates = estimate_fuel_rates_from_inputs(fuel_ash_inputs)
             fuel_rate_source = "fuel_ash_inputs"
 
-    preliminary_fuel_inputs = (
-        _fuel_inputs_with_rates(fuel_ash_inputs, fuel_rates)
-        if fuel_rates is not None
-        else list(fuel_ash_inputs or [])
-    )
+    # Which fuel rates generate the ash in THIS blend's slag balance.
+    #
+    # Default: the operator's Fuel Ash rows, untouched. Those are the rates the
+    # LP built its slag / basicity / T-basicity / Al2O3 / MgO rows against, so
+    # using anything else here means the displayed slag is not the slag that was
+    # constrained. Substituting the back-solved coke rate (~296 kg/THM against a
+    # table 312.67) shifted B2 by about +0.011 and T basicity by +0.012, which is
+    # enough on its own to push a blend that the LP placed exactly on a 1.150
+    # ceiling out to 1.151, and a T basicity on 1.364 out to 1.376.
+    #
+    # DE opts into the substitution because its objective prices the back-solved
+    # and corrected fuel, so its slag has to be on that same basis.
+    preliminary_fuel_inputs = list(fuel_ash_inputs or [])
+    if recompute_slag_with_corrected_fuel and fuel_rates is not None:
+        preliminary_fuel_inputs = _fuel_inputs_with_rates(fuel_ash_inputs, fuel_rates)
     blend = evaluate_blend(
         ores=ores,
         quantities_mt=quantities,
@@ -367,34 +393,47 @@ def evaluate_blend_with_fuel_prediction(
         if correction is not None:
             fuel_rates = correction
 
-        # The corrected rates are the rates used by the final slag/material
-        # balance.  Re-evaluate once so slag, B2/IB4, dust conversion, charging,
-        # and the displayed fuel rates are one internally consistent result.
-        final_fuel_inputs = _fuel_inputs_with_rates(fuel_ash_inputs, fuel_rates)
+        # Stage 2 does NOT rewrite stage 1.
+        #
+        # The slag on ``blend`` was computed from the operator's Fuel Ash rates,
+        # and that is the slag the LP placed its rate / basicity / T-basicity /
+        # Al2O3 / MgO rows against. Re-running the balance here with the
+        # back-solved and physics-corrected coke rate moved every one of those
+        # ratios after the fact, so the page showed a basicity the LP had never
+        # agreed to (measured: up to ~0.04 on B2, ~0.05 on T-basicity).
+        #
+        # The corrected rates are reported instead, on the untouched blend.
+        # DE opts back into the feedback because its objective prices the
+        # corrected fuel, so it needs slag on that same basis.
         carried_diagnostics = dict(blend.diagnostics)
-        final_blend = evaluate_blend(
-            ores=ores,
-            quantities_mt=quantities,
-            feo_in_slag_pct=feo_in_slag_pct,
-            fuel_cost_per_thm_rs=float(blend.fuel_cost_per_thm_rs),
-            fuel_ash_inputs=final_fuel_inputs,
-            flux_inputs=flux_inputs,
-            dust_inputs=dust_inputs,
-            slag_balance_settings=slag_balance_settings,
-            hot_metal_target_mt=hot_metal_target_mt,
-            charge_mass_mt=charge_mass_mt,
+        if recompute_slag_with_corrected_fuel:
+            final_fuel_inputs = _fuel_inputs_with_rates(fuel_ash_inputs, fuel_rates)
+            final_blend = evaluate_blend(
+                ores=ores,
+                quantities_mt=quantities,
+                feo_in_slag_pct=feo_in_slag_pct,
+                fuel_cost_per_thm_rs=float(blend.fuel_cost_per_thm_rs),
+                fuel_ash_inputs=final_fuel_inputs,
+                flux_inputs=flux_inputs,
+                dust_inputs=dust_inputs,
+                slag_balance_settings=slag_balance_settings,
+                hot_metal_target_mt=hot_metal_target_mt,
+                charge_mass_mt=charge_mass_mt,
+            )
+            for key in (
+                "fuel_cost_per_thm_rs_model",
+                "fuel_cost_rebase_rs_per_thm",
+                "fuel_cost_per_thm_rs_uncorrected",
+                "coke_correction",
+                "coke_correction_delta_kg_thm",
+                "coke_correction_applied",
+            ):
+                if key in carried_diagnostics:
+                    final_blend.diagnostics[key] = carried_diagnostics[key]
+            blend = final_blend
+        blend.diagnostics["slag_recomputed_with_corrected_fuel"] = bool(
+            recompute_slag_with_corrected_fuel
         )
-        for key in (
-            "fuel_cost_per_thm_rs_model",
-            "fuel_cost_rebase_rs_per_thm",
-            "fuel_cost_per_thm_rs_uncorrected",
-            "coke_correction",
-            "coke_correction_delta_kg_thm",
-            "coke_correction_applied",
-        ):
-            if key in carried_diagnostics:
-                final_blend.diagnostics[key] = carried_diagnostics[key]
-        blend = final_blend
         blend.diagnostics["fuel_rate_estimate_anchor"] = carried_diagnostics[
             "fuel_rate_estimate_anchor"
         ]

--- a/src/utils/bmo/lp_solver.py
+++ b/src/utils/bmo/lp_solver.py
@@ -387,6 +387,7 @@ def _explain_lp_infeasibility(
     hot_metal_target_mt: float | None,
     coke_correction_settings: CokeCorrectionSettings | None = None,
     coke_correction_reference: CokeCorrectionReference | None = None,
+    price_coke_correction: bool = False,
 ) -> list[str]:
     """
     Explain an infeasible LP by isolating the binding constraint family.
@@ -454,6 +455,7 @@ def _explain_lp_infeasibility(
             hot_metal_target_mt=hot_metal_target_mt,
             coke_correction_settings=coke_correction_settings,
             coke_correction_reference=coke_correction_reference,
+            price_coke_correction=price_coke_correction,
             _explain=False,
         )
         if without_burden_cap is not None:
@@ -482,6 +484,7 @@ def _explain_lp_infeasibility(
         hot_metal_target_mt=hot_metal_target_mt,
         coke_correction_settings=coke_correction_settings,
         coke_correction_reference=coke_correction_reference,
+        price_coke_correction=price_coke_correction,
     )
     # Every slag limit currently in force, and how to describe it once we know
     # which one is doing the blocking. Each is dropped in turn, cheapest and
@@ -679,6 +682,7 @@ def run_lp_baseline(
     hot_metal_target_mt: float | None = None,
     coke_correction_settings: CokeCorrectionSettings | None = None,
     coke_correction_reference: CokeCorrectionReference | None = None,
+    price_coke_correction: bool = False,
     charge_mass_mt: float = 26.4,
     _explain: bool = True,
 ) -> tuple[BlendEvaluation | None, list[str]]:
@@ -813,21 +817,34 @@ def run_lp_baseline(
     a_ub_rows.append(slag_coeff)
     b_ub_values.append(float(target_slag_qty_mt) - slag_base_mt)
 
-    # Price the physics coke correction into the objective. Without it the LP
-    # sees no fuel consequence at all for a leaner burden - the fuel model is
-    # blend-blind - so it buys the cheapest, highest-gangue material available
-    # and only discovers the coke bill afterwards, on the display.
+    # Optionally price the physics coke correction into the objective.
+    #
+    # OFF by default. The LP's job is to pick the cheapest ore + flux mix that
+    # satisfies the slag rate, basicity, T-basicity, Al2O3, MgO and MgO/Al2O3
+    # limits - nothing else. Slag is governed by those hard constraints, not by
+    # a fuel term in the cost vector, so the reported cost is the purchase cost
+    # of a real basket of material and nothing has to be unpicked to explain it.
+    #
+    # DE is a different optimiser with a different objective (ore + predicted
+    # fuel, slag limits as soft penalties). Its seed LP must be optimised against
+    # the objective DE will actually use, otherwise the seed lands in a corner DE
+    # only explores a few percent around, so ``run_nonlinear_optimizer`` turns
+    # this on for its seed call.
     #
     # This changes only ``c``, never ``A_ub``/``b_ub``, so every constraint and
-    # the exact-slag retry loop below behave exactly as before.
-    coke_correction_coeffs = build_linear_coke_correction_cost_coeffs(
-        ores=ores,
-        variable_fluxes=variable_fluxes,
-        settings=coke_correction_settings or CokeCorrectionSettings(),
-        slag_coeff=slag_coeff,
-        hot_metal_target_mt=float(hot_metal_target_mt or target_production_mt or 0.0),
-    )
-    c = c + coke_correction_coeffs
+    # the exact-slag retry loop below behave identically either way.
+    coke_correction_coeffs = np.zeros(n + n_flux, dtype=float)
+    if price_coke_correction:
+        coke_correction_coeffs = build_linear_coke_correction_cost_coeffs(
+            ores=ores,
+            variable_fluxes=variable_fluxes,
+            settings=coke_correction_settings or CokeCorrectionSettings(),
+            slag_coeff=slag_coeff,
+            hot_metal_target_mt=float(
+                hot_metal_target_mt or target_production_mt or 0.0
+            ),
+        )
+        c = c + coke_correction_coeffs
 
     # Charging-throughput ceiling: every ore and flux tonne occupies room in the
     # same charges, so they share one budget. Without it the LP can meet the Fe
@@ -1003,6 +1020,7 @@ def run_lp_baseline(
                         hot_metal_target_mt=hot_metal_target_mt,
                         coke_correction_settings=coke_correction_settings,
                         coke_correction_reference=coke_correction_reference,
+                        price_coke_correction=price_coke_correction,
                     )
                 )
             return None, messages

--- a/src/utils/bmo/nonlinear_optimizer.py
+++ b/src/utils/bmo/nonlinear_optimizer.py
@@ -307,8 +307,13 @@ def run_nonlinear_optimizer(
             # Seeding from an uncorrected LP would drop DE into the low-Fe corner
             # the correction exists to avoid, and DE only explores a few percent
             # around its seed - it would never find its way back out.
+            #
+            # This is why ``price_coke_correction`` exists as a flag rather than
+            # being deleted: the page's own LP is a pure ore-cost solve, but DE
+            # optimises ore + predicted fuel and its seed has to match.
             coke_correction_settings=coke_correction_settings,
             coke_correction_reference=coke_correction_reference,
+            price_coke_correction=True,
             charge_mass_mt=charge_mass_mt,
         )
     if lp_blend is None and seed_strategy == "lp":

--- a/src/utils/bmo/objective.py
+++ b/src/utils/bmo/objective.py
@@ -251,7 +251,11 @@ class BmoObjectiveEvaluator:
             for j, flux in enumerate(self.variable_fluxes)
         ]
 
+        # DE prices the CORRECTED fuel in its objective, so its slag has to be on
+        # the corrected-fuel basis too. The page's LP path deliberately does not
+        # do this - see ``evaluate_blend_with_fuel_prediction``.
         blend = evaluate_blend_with_fuel_prediction(
+            recompute_slag_with_corrected_fuel=True,
             ores=self.ores,
             quantities_mt=quantities,
             feo_in_slag_pct=self.feo_in_slag_pct,

--- a/tests/test_bmo_coke_correction_objective.py
+++ b/tests/test_bmo_coke_correction_objective.py
@@ -294,6 +294,9 @@ def _lp(*, settings=None, slag_cap: float = 400.0):
         feo_in_slag_pct=0.0,
         hot_metal_target_mt=_HM_MT,
         coke_correction_settings=settings,
+        # The LP now defaults to a pure ore-cost objective; these
+        # tests exercise the correction-pricing path DE still uses.
+        price_coke_correction=settings is not None,
     )
 
 

--- a/tests/test_bmo_coke_correction_sweep.py
+++ b/tests/test_bmo_coke_correction_sweep.py
@@ -189,6 +189,9 @@ def _run_lp(*, k_slag: float, slag_cap: float, ores=None, **kwargs):
         flux_inputs=[_limestone()],
         hot_metal_target_mt=_HM_MT,
         coke_correction_settings=settings,
+        # The LP now defaults to a pure ore-cost objective; these
+        # tests exercise the correction-pricing path DE still uses.
+        price_coke_correction=settings is not None,
         coke_correction_reference=_reference(),
     )
 
@@ -213,6 +216,9 @@ def _lp_with_fuel(*, k_slag: float, slag_cap: float, reference=None, **kwargs):
         flux_inputs=[_limestone()],
         hot_metal_target_mt=_HM_MT,
         coke_correction_settings=settings,
+        # The LP now defaults to a pure ore-cost objective; these
+        # tests exercise the correction-pricing path DE still uses.
+        price_coke_correction=settings is not None,
         coke_correction_reference=reference if reference is not None else _reference(),
     )
     if physical is None:

--- a/tests/test_bmo_fuel_reprice.py
+++ b/tests/test_bmo_fuel_reprice.py
@@ -83,6 +83,7 @@ def _blend(
     *,
     model_value: float = 12_900.0,
     fuel_rate_basis: str = "model_cost",
+    recompute_slag_with_corrected_fuel: bool = False,
 ):
     return evaluate_blend_with_fuel_prediction(
         ores=[_ore("ore_a", sio2=8.0, cao=1.0), _ore("ore_b", sio2=7.0, cao=1.5)],
@@ -94,6 +95,7 @@ def _blend(
         fuel_ash_inputs=fuel_ash,
         hot_metal_target_mt=100.0,
         fuel_rate_basis=fuel_rate_basis,
+        recompute_slag_with_corrected_fuel=recompute_slag_with_corrected_fuel,
     )
 
 
@@ -169,14 +171,46 @@ def test_default_basis_converts_model_cost_and_stays_blend_sensitive():
     )
 
 
-def test_final_slag_evaluation_uses_the_displayed_fuel_rates():
-    blend = _blend(_fuel_ash(28_000.0, 24_000.0, 18_000.0))
-    displayed = blend.diagnostics["fuel_rate_estimate"]
-    used = {
+def _fuel_usage(blend) -> dict:
+    return {
         row["fuel_id"]: row
         for row in blend.diagnostics["fuel_usage"]
         if row["enabled"]
     }
+
+
+def test_slag_uses_the_table_rates_not_the_back_solved_ones():
+    """The slag balance runs on the operator's Fuel Ash rows, full stop.
+
+    Those are the rates the LP built its slag / basicity / T-basicity / Al2O3 /
+    MgO rows against. Substituting the back-solved coke rate here used to shift
+    the displayed B2 by ~+0.011 and T basicity by ~+0.012 - enough to push a
+    blend the LP had placed exactly on a 1.150 ceiling out to 1.151, reported as
+    a constraint violation on a solution that never violated anything.
+    """
+
+    fuel_ash = _fuel_ash(28_000.0, 24_000.0, 18_000.0)
+    table_coke = next(f.rate_kg_per_thm for f in fuel_ash if f.fuel_id == "coke")
+    blend = _blend(fuel_ash)
+    used = _fuel_usage(blend)
+
+    assert used["coke"]["rate_kg_per_thm"] == pytest.approx(table_coke)
+    # The back-solved rate is still reported, and is genuinely different - which
+    # is exactly why it must not be the one generating ash.
+    displayed = blend.diagnostics["fuel_rate_estimate"]
+    assert displayed["coke_rate_kg_thm"] != pytest.approx(table_coke)
+    assert blend.diagnostics["slag_recomputed_with_corrected_fuel"] is False
+
+
+def test_de_still_ties_slag_to_the_displayed_fuel_rates():
+    """DE prices corrected fuel in its objective, so it opts back in."""
+
+    blend = _blend(
+        _fuel_ash(28_000.0, 24_000.0, 18_000.0),
+        recompute_slag_with_corrected_fuel=True,
+    )
+    displayed = blend.diagnostics["fuel_rate_estimate"]
+    used = _fuel_usage(blend)
 
     assert used["coke"]["rate_kg_per_thm"] == pytest.approx(
         displayed["coke_rate_kg_thm"]
@@ -187,6 +221,7 @@ def test_final_slag_evaluation_uses_the_displayed_fuel_rates():
     assert used["pci"]["rate_kg_per_thm"] == pytest.approx(
         displayed["pci_rate_kg_thm"]
     )
+    assert blend.diagnostics["slag_recomputed_with_corrected_fuel"] is True
 
 
 def test_inputs_basis_uses_actual_current_rates_not_model_prediction():

--- a/tests/test_bmo_operator_ui_changes.py
+++ b/tests/test_bmo_operator_ui_changes.py
@@ -545,13 +545,19 @@ def test_main_metrics_show_production_and_requested_charging_values(monkeypatch)
     assert "Planning HM/charge (MT)" not in captured
     hidden = {
         "Fe Produced (MT)",
-        "Slag T Basicity",
         "Dry Qty (MT)",
         "IBRM + Flux (MT)",
         "Total Charge Mix (MT)",
         "Charge Mix (MT/hr)",
     }
     assert hidden.isdisjoint(captured)
+    # "Slag T Basicity" was hidden alongside the five above, but it does not
+    # belong with them: those are informational, whereas T Basicity is a HARD
+    # optimizer constraint driven by the Min/Max T Basicity inputs. Hiding it
+    # left the optimizer enforcing a limit the operator could not see - and IB4
+    # took its display slot, so a tile expected to read ~1.31 read ~0.85.
+    assert "Slag T Basicity" in captured
+    assert "IB4" in captured
 
 
 def _flux_df():

--- a/tests/test_bmo_slag_quality_window.py
+++ b/tests/test_bmo_slag_quality_window.py
@@ -366,3 +366,49 @@ def test_de_slag_chemistry_penalty_weight_is_separately_configurable():
     assert dear.components["penalty_slag_al2o3"] == pytest.approx(
         cheap.components["penalty_slag_al2o3"] * 10.0
     )
+
+
+# --- The three basicity indices are distinct and must not be confused --------
+
+
+def test_b2_t_basicity_and_ib4_are_three_different_indices():
+    """Pins the scale of each, because IB4 already got mistaken for T Basicity.
+
+    IB4 puts Al2O3 (~19% of slag) into the denominator, so it reads far LOWER
+    than T Basicity off the same slag. Plant reference over 6,515 hours of
+    HM_SLAG analysis:
+
+        B2  = CaO/SiO2               mean 1.079
+        T.B = (CaO+MgO)/SiO2         mean 1.309
+        IB4 = (CaO+MgO)/(SiO2+Al2O3) mean 0.844
+
+    A ~0.85 IB4 is correct. A ~0.85 T Basicity would not be.
+    """
+
+    ores = [_ore("ore", al2o3=2.5, mgo=1.2, sio2=5.0, cao=5.5)]
+    blend = _blend(ores, {"ore": 1000.0})
+
+    cao = blend.diagnostics["slag_basicity_cao_mt"]
+    mgo = blend.diagnostics["slag_mgo_mt"]
+    sio2 = blend.diagnostics["slag_basicity_sio2_mt"]
+    al2o3 = blend.diagnostics["slag_al2o3_mt"]
+
+    assert blend.slag_basicity == pytest.approx(cao / sio2)
+    assert blend.slag_t_basicity == pytest.approx((cao + mgo) / sio2)
+    assert blend.slag_ib4 == pytest.approx((cao + mgo) / (sio2 + al2o3))
+
+    # Ordering is structural: same numerator, bigger denominator.
+    assert blend.slag_ib4 < blend.slag_t_basicity
+    assert blend.slag_basicity < blend.slag_t_basicity
+
+
+def test_ib4_and_t_basicity_reproduce_the_plant_slag_analysis():
+    """Both indices, computed from a slag matching the plant's mean analysis."""
+
+    # Plant mean slag: CaO 36.66, MgO 7.82, SiO2 34.02, Al2O3 18.71 (%).
+    cao, mgo, sio2, al2o3 = 36.66, 7.82, 34.02, 18.71
+
+    assert (cao + mgo) / sio2 == pytest.approx(1.309, abs=0.01)
+    assert (cao + mgo) / (sio2 + al2o3) == pytest.approx(0.844, abs=0.01)
+    # The gap between them is the whole reason they get confused.
+    assert (cao + mgo) / sio2 - (cao + mgo) / (sio2 + al2o3) > 0.4

--- a/tests/test_bmo_two_stage_split.py
+++ b/tests/test_bmo_two_stage_split.py
@@ -1,0 +1,321 @@
+"""Blend selection and fuel estimation are two stages, and stage 2 is read-only.
+
+Stage 1 - the LP picks the cheapest ore + flux basket that satisfies the slag
+rate, basicity, T-basicity, Al2O3, MgO and MgO/Al2O3 limits. Slag comes from the
+blend plus the fuel-ash rates the operator entered. Nothing else is in the
+objective.
+
+Stage 2 - the ML model predicts fuel unit cost for that blend, a coke rate is
+back-solved from it against the table's prices, and the physics correction is
+applied. This is REPORTING. It must not move the slag the LP agreed to.
+
+The old behaviour re-ran the slag balance with the corrected coke rate, so the
+displayed basicity was not the basicity the LP had solved for - up to ~0.04 on
+B2. DE still opts into that feedback because its objective genuinely prices
+corrected fuel; the LP display path does not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.bmo.calculations import evaluate_blend
+from utils.bmo.coke_correction import load_coke_correction_settings
+from utils.bmo.fuel_rates import estimate_fuel_rates_from_cost
+from utils.bmo.lp_solver import run_lp_baseline
+from utils.bmo.types import FuelAshInput, OreChemistry, OreInput
+
+_HM_MT = 100.0
+
+
+def _correction_settings(k_slag: float = 30.0):
+    """Settings with a live slag term, so pricing them actually moves the LP.
+
+    A bare ``CokeCorrectionSettings()`` has every term disabled and would make
+    these tests pass without proving anything.
+    """
+
+    return load_coke_correction_settings(
+        {
+            "coke_rate_correction": {
+                "enabled": True,
+                "apply_to_objective": True,
+                "guardrails": {
+                    "max_abs_correction_kg_thm": 60.0,
+                    "taper_start_fraction": 0.6,
+                    "coke_rate_band_kg_thm": [200.0, 500.0],
+                    "total_fuel_rate_band_kg_thm": [400.0, 800.0],
+                },
+                "terms": {
+                    "slag_heat": {
+                        "enabled": True,
+                        "kg_coke_per_100kg_slag": k_slag,
+                        "max_abs_kg_thm": 45.0,
+                        "reference_source": "model_current",
+                    }
+                },
+            }
+        }
+    )
+
+
+def _ore(ore_id: str, *, fe_t: float, sio2: float, price: float) -> OreInput:
+    return OreInput(
+        ore_id=ore_id,
+        display_name=ore_id.upper(),
+        stock_mt=10_000.0,
+        price_rs_per_mt=price,
+        min_share_pct=0.0,
+        max_share_pct=100.0,
+        chemistry=OreChemistry(
+            fe_t_pct=fe_t, sio2_pct=sio2, al2o3_pct=2.0, cao_pct=4.0, mgo_pct=1.5
+        ),
+    )
+
+
+def _fuels(coke_rate: float = 300.0) -> list[FuelAshInput]:
+    return [
+        FuelAshInput(
+            fuel_id="coke", display_name="Coke", enabled=True,
+            rate_kg_per_thm=coke_rate, price_rs_per_mt=28_000.0,
+            ash_pct=12.0, sio2_pct=57.0, al2o3_pct=26.0, cao_pct=2.7, mgo_pct=1.0,
+        ),
+        FuelAshInput(
+            fuel_id="nut_coke", display_name="Nut Coke", enabled=True,
+            rate_kg_per_thm=76.44, price_rs_per_mt=24_000.0,
+            ash_pct=12.5, sio2_pct=57.0, al2o3_pct=27.0, cao_pct=2.7, mgo_pct=1.0,
+        ),
+        FuelAshInput(
+            fuel_id="pci", display_name="PCI", enabled=True,
+            rate_kg_per_thm=180.0, price_rs_per_mt=18_000.0,
+            ash_pct=8.6, sio2_pct=50.0, al2o3_pct=28.0, cao_pct=5.2, mgo_pct=1.9,
+        ),
+    ]
+
+
+def _lp(**kwargs):
+    ores = [
+        _ore("lean", fe_t=52.0, sio2=9.0, price=900.0),
+        _ore("rich", fe_t=64.0, sio2=3.0, price=1600.0),
+    ]
+    call = dict(
+        target_production_mt=60.0,
+        target_slag_qty_mt=400.0,
+        feo_in_slag_pct=0.0,
+        hot_metal_target_mt=_HM_MT,
+    )
+    call.update(kwargs)
+    return run_lp_baseline(ores, **call)
+
+
+# --- Stage 1: the LP objective is ore + flux purchase cost, nothing else -----
+
+
+def test_lp_objective_is_ore_cost_only_by_default() -> None:
+    """A coke-correction setting must not change the answer unless asked for.
+
+    The LP's job is the cheapest basket that satisfies the slag limits. Slag is
+    governed by the hard constraints, not by a fuel term in the cost vector.
+    """
+
+    plain, errors_plain = _lp()
+    with_settings, errors_settings = _lp(
+        coke_correction_settings=_correction_settings()
+    )
+
+    assert errors_plain == [] and errors_settings == []
+    assert plain is not None and with_settings is not None
+    assert with_settings.quantities_mt == pytest.approx(plain.quantities_mt)
+    assert with_settings.ore_cost_total_rs == pytest.approx(plain.ore_cost_total_rs)
+
+
+def test_lp_does_not_record_priced_correction_terms_by_default() -> None:
+    plain, _ = _lp(coke_correction_settings=_correction_settings())
+
+    assert plain is not None
+    assert "lp_coke_correction_linear_terms" not in plain.diagnostics
+
+
+def test_correction_pricing_is_still_available_for_de_seeding() -> None:
+    """The mechanism is gated, not deleted - run_nonlinear_optimizer needs it."""
+
+    settings = _correction_settings()
+    off, _ = _lp(coke_correction_settings=settings)
+    on, errors = _lp(coke_correction_settings=settings, price_coke_correction=True)
+
+    assert errors == []
+    assert on is not None and off is not None
+    # Pricing slag into the objective pushes the LP toward the richer ore.
+    assert on.fe_t_pct > off.fe_t_pct
+    assert "lp_coke_correction_linear_terms" in on.diagnostics
+
+
+# --- Stage 2 must not disturb stage 1 ----------------------------------------
+
+
+def test_coke_rate_zero_removes_only_its_slag_contribution() -> None:
+    """Deliberately zeroing coke in the Fuel Ash table is a slag-only lever."""
+
+    ore = _ore("burden", fe_t=56.0, sio2=5.6, price=7000.0)
+    quantities = {"burden": 3900.0}
+
+    with_coke = evaluate_blend(
+        ores=[ore], quantities_mt=quantities, feo_in_slag_pct=0.4,
+        fuel_cost_per_thm_rs=0.0, fuel_ash_inputs=_fuels(coke_rate=300.0),
+        hot_metal_target_mt=2350.0,
+    )
+    without_coke = evaluate_blend(
+        ores=[ore], quantities_mt=quantities, feo_in_slag_pct=0.4,
+        fuel_cost_per_thm_rs=0.0, fuel_ash_inputs=_fuels(coke_rate=0.0),
+        hot_metal_target_mt=2350.0,
+    )
+
+    # The drop is exactly the SLAG-FORMING oxides in the coke ash that is no
+    # longer charged - not the whole ash. Ash that is not one of the tracked
+    # oxides never reported to slag in the first place.
+    coke_ash_mt = 300.0 * 2350.0 / 1000.0 * 0.12
+    slag_forming_fraction = (57.0 + 26.0 + 2.7 + 1.0) / 100.0
+    assert without_coke.slag_mt < with_coke.slag_mt
+    assert with_coke.slag_mt - without_coke.slag_mt == pytest.approx(
+        coke_ash_mt * slag_forming_fraction
+    )
+    # The blend itself is untouched - this is a fuel-ash lever, not an ore lever.
+    assert without_coke.quantities_mt == pytest.approx(with_coke.quantities_mt)
+    assert without_coke.fe_production_mt == pytest.approx(with_coke.fe_production_mt)
+
+
+def test_coke_rate_zero_does_not_move_the_back_solved_fuel_rates() -> None:
+    """Coke rate is the residual of the cost decomposition, never an input to it.
+
+    So the operator can zero the coke row to strip its ash from the slag without
+    disturbing a single number on the fuel side.
+    """
+
+    common = dict(
+        fuel_cost_per_thm_rs=13_364.0, process_context={}, history_df=None
+    )
+    normal = estimate_fuel_rates_from_cost(fuel_ash_inputs=_fuels(300.0), **common)
+    zeroed = estimate_fuel_rates_from_cost(fuel_ash_inputs=_fuels(0.0), **common)
+
+    assert normal is not None and zeroed is not None
+    assert zeroed.coke_rate_kg_thm == pytest.approx(normal.coke_rate_kg_thm)
+    assert zeroed.nut_coke_rate_kg_thm == pytest.approx(normal.nut_coke_rate_kg_thm)
+    assert zeroed.pci_rate_kg_thm == pytest.approx(normal.pci_rate_kg_thm)
+    assert zeroed.total_fuel_rate_kg_thm == pytest.approx(
+        normal.total_fuel_rate_kg_thm
+    )
+
+
+def test_nut_coke_and_pci_rates_come_from_the_table() -> None:
+    """Both are read straight off the Fuel Ash rows, so slag and the cost
+    decomposition can never be looking at different numbers."""
+
+    rates = estimate_fuel_rates_from_cost(
+        fuel_cost_per_thm_rs=13_364.0,
+        fuel_ash_inputs=_fuels(),
+        process_context={},
+        history_df=None,
+    )
+
+    assert rates is not None
+    assert rates.nut_coke_rate_kg_thm == pytest.approx(76.44)
+    assert rates.pci_rate_kg_thm == pytest.approx(180.0)
+    assert rates.nut_coke_source == "fuel_ash_inputs.nut_coke.rate_kg_per_thm"
+    assert rates.pci_source == "fuel_ash_inputs.pci.rate_kg_per_thm"
+
+
+def test_editing_a_fuel_price_never_moves_the_slag() -> None:
+    """Prices belong to stage 2 only."""
+
+    ore = _ore("burden", fe_t=56.0, sio2=5.6, price=7000.0)
+    cheap = _fuels()
+    dear = [
+        FuelAshInput(**{**f.__dict__, "price_rs_per_mt": f.price_rs_per_mt * 2.0})
+        for f in _fuels()
+    ]
+
+    a = evaluate_blend(
+        ores=[ore], quantities_mt={"burden": 3900.0}, feo_in_slag_pct=0.4,
+        fuel_cost_per_thm_rs=0.0, fuel_ash_inputs=cheap, hot_metal_target_mt=2350.0,
+    )
+    b = evaluate_blend(
+        ores=[ore], quantities_mt={"burden": 3900.0}, feo_in_slag_pct=0.4,
+        fuel_cost_per_thm_rs=0.0, fuel_ash_inputs=dear, hot_metal_target_mt=2350.0,
+    )
+
+    assert a.slag_mt == pytest.approx(b.slag_mt)
+    assert a.slag_basicity == pytest.approx(b.slag_basicity)
+    assert a.slag_al2o3_pct == pytest.approx(b.slag_al2o3_pct)
+
+
+# --- The displayed blend must BE the LP's blend -------------------------------
+
+
+class _Prediction:
+    value = 13_364.0
+    details: dict = {}
+    used_fallback = False
+    model_loaded = True
+    scaler_loaded = True
+    missing_features: list = []
+    imputed_features: list = []
+
+
+class _ModelService:
+    def predict(self, feature_payload, history_df):
+        return _Prediction()
+
+
+def test_displayed_basicity_equals_the_basicity_the_lp_solved():
+    """The bug this guards: LP lands on the bound, display reports a violation.
+
+    The LP drives basicity exactly onto its ceiling. If the display path
+    re-evaluates slag on any other fuel basis, the exact value moves off the
+    bound and the page reports a constraint violation for a solution that never
+    violated one. Observed live as "1.151 > 1.150" and "1.376 > 1.364".
+    """
+
+    from utils.bmo.fuel_prediction import evaluate_blend_with_fuel_prediction
+
+    ores = [
+        _ore("lean", fe_t=52.0, sio2=9.0, price=900.0),
+        _ore("rich", fe_t=64.0, sio2=3.0, price=1600.0),
+    ]
+    fuels = _fuels()
+    b2_max = 0.60
+
+    lp, errors = run_lp_baseline(
+        ores,
+        target_production_mt=60.0,
+        target_slag_qty_mt=1.0e6,
+        feo_in_slag_pct=0.0,
+        target_slag_basicity_max=b2_max,
+        fuel_ash_inputs=fuels,
+        hot_metal_target_mt=_HM_MT,
+    )
+    assert errors == [] and lp is not None and lp.feasible
+
+    shown = evaluate_blend_with_fuel_prediction(
+        ores=ores,
+        quantities_mt=lp.quantities_mt,
+        feo_in_slag_pct=0.0,
+        model_service=_ModelService(),
+        process_context={},
+        history_df=None,
+        fuel_ash_inputs=fuels,
+        hot_metal_target_mt=_HM_MT,
+    )
+
+    assert shown.slag_basicity == pytest.approx(lp.slag_basicity)
+    assert shown.slag_t_basicity == pytest.approx(lp.slag_t_basicity)
+    assert shown.slag_mt == pytest.approx(lp.slag_mt)
+    assert shown.slag_al2o3_pct == pytest.approx(lp.slag_al2o3_pct)
+    # And therefore re-validating the displayed blend finds nothing wrong.
+    from utils.bmo.constraints import check_blend_constraints
+
+    assert check_blend_constraints(
+        shown, ores,
+        target_production_mt=60.0,
+        target_slag_qty_mt=1.0e6,
+        target_slag_basicity_max=b2_max,
+    ) == []


### PR DESCRIPTION
The LP was optimising one thing and the page was displaying another. Its cost vector carried the physics coke-correction term, and the solved blend was then re-evaluated on a different fuel basis before display. Fuel ash is a large slag contributor, so that moved every slag ratio the LP had just constrained, and the page reported constraint violations against solutions that never violated anything - observed live as 1.151 > 1.150 and 1.376 > 1.364.

Split the two stages and stop the second feeding back into the first.

Stage 1, the LP, now minimises ore + flux purchase cost and nothing else. Slag is governed by the hard rate / basicity / T-basicity / Al2O3 / MgO / MgO:Al2O3 limits rather than by a fuel term in the objective, so the reported cost is the purchase cost of a real basket of material. Slag comes from the blend plus the fuel-ash rates the operator entered, which is exactly what gets displayed.

Stage 2 predicts fuel unit cost for that blend, back-solves a coke rate against the table's prices, and applies the physics correction. It is reporting only.

The fuel rates were being substituted in TWO places, not one. The obvious one re-ran the whole balance with the corrected rates after the correction was applied. The other was upstream and easy to miss: the blend was built from _fuel_inputs_with_rates() in the first place, so the slag was generated by the back-solved coke rate (~296 kg/THM) rather than the table's (312.67) before any correction existed. On a blend the LP placed exactly on a 1.150 basicity ceiling that second path alone shifted B2 by +0.0116 and T basicity by +0.0141. Both now default to the operator's rows; the displayed blend reproduces the LP's slag, basicity, T basicity and Al2O3 exactly, and re-validates clean.

Not linearisation error: measured, the LP's linear slag and basicity rows agree with the exact re-evaluation to 0.0000, because the balance is genuinely linear in ore quantities. No basicity retry loop is needed.

Both entry points are shared with DE, which legitimately optimises ore plus predicted fuel with the slag limits as soft penalties, so the old behaviour is gated rather than deleted: run_lp_baseline takes price_coke_correction and evaluate_blend_with_fuel_prediction takes recompute_slag_with_corrected_fuel, both defaulting off and both set by DE. DE's seed LP must be optimised against the objective DE will actually use, since it only explores a few percent around its seed. DE behaviour is unchanged.

Restore the Slag T Basicity tile and comparison-table row. It was hidden by 6333129 in a batch declutter of six metrics and IB4 later took its display slot, so a value expected to read ~1.31 read ~0.85. IB4 is correct at ~0.85 - it puts Al2O3, ~19% of the slag, into the denominator - but T basicity is a hard constraint driven by the Min/Max T Basicity inputs, and hiding it left the optimizer enforcing a bound the operator could not see. That commit's hidden-metrics assertion is updated accordingly; the other five stay hidden. Plant reference over 6,515 hours: B2 1.079, T basicity 1.309, IB4 0.844.

Make the Fuel Ash table's role explicit: the rows exist to put fuel ash into the slag balance, and setting a rate to 0 drops that ash and nothing else. Only the prices and the nut coke and PCI rates are read by the fuel step; coke rate is back-solved from predicted cost and is never an input to it. Verified: zeroing coke takes slag from 791.25 to 706.48 MT while the back-solved coke rate stays at 296.05 kg/THM.

Twelve existing tests asserted the old behaviour. Eleven exercise the pricing path DE still uses and now opt in rather than being deleted; test_final_slag_evaluation_uses_the_displayed_fuel_rates required slag to run on the back-solved rates, so it is split into one test per path. New coverage for the two-stage split, for the displayed blend reproducing the LP's, and for the three basicity indices being distinct.

294 passed, 1 skipped.